### PR TITLE
Visually aligning our date picker calendar tokens to align with carbon

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1771,7 +1771,7 @@
             "m": {
               "value": {
                 "fontFamily": "$fontFamilies.default",
-                "fontWeight": "$fontWeights.700",
+                "fontWeight": "$fontWeights.500",
                 "lineHeight": "$lineHeights.500",
                 "fontSize": "$fontSizes.100",
                 "letterSpacing": "0%",


### PR DESCRIPTION
The font weight assigned was too heavy. I've reduced it to our new medium weight.
