### PR TITLE
Adjusting Action Popover Menu Item weight

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1632,7 +1632,7 @@
           "m": {
             "value": {
               "fontFamily": "$fontFamilies.default",
-              "fontWeight": "$fontWeights.700",
+              "fontWeight": "$fontWeights.500",
               "lineHeight": "$lineHeights.500",
               "fontSize": "$fontSizes.100",
               "letterSpacing": "0%",


### PR DESCRIPTION
changing font weight for action popover menu items from 700 to 500. This is because only headings should use the 700 weight.