### PR TITLE
feat(data): add 2 new typography tokens for breadcrumbs

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1699,6 +1699,32 @@
           }
         }
       },
+      "breadcrumb": {
+        "separator": {
+          "m": {
+            "value": {
+              "fontFamily": "{fontFamilies.default}",
+              "fontWeight": "{fontWeights.400}",
+              "lineHeight": "{lineHeights.500}",
+              "fontSize": "{fontSizes.100}"
+            },
+            "type": "typography",
+            "description": "Style for the slash forward character that separates the breadcrumbs"
+          }
+        },
+        "currentPage": {
+          "m": {
+            "value": {
+              "fontFamily": "{fontFamilies.default}",
+              "fontWeight": "{fontWeights.400}",
+              "lineHeight": "{lineHeights.500}",
+              "fontSize": "{fontSizes.100}"
+            },
+            "type": "typography",
+            "description": "Style for the current page text"
+          }
+        }
+      },
       "button": {
         "label": {
           "s": {
@@ -3514,32 +3540,6 @@
               "paragraphSpacing": "0px"
             },
             "type": "typography"
-          }
-        }
-      },
-      "breadcrumb": {
-        "separator": {
-          "m": {
-            "value": {
-              "fontFamily": "{fontFamilies.default}",
-              "fontWeight": "{fontWeights.400}",
-              "lineHeight": "{lineHeights.500}",
-              "fontSize": "{fontSizes.100}"
-            },
-            "type": "typography",
-            "description": "Style for the slash forward character that separates the breadcrumbs"
-          }
-        },
-        "currentPage": {
-          "m": {
-            "value": {
-              "fontFamily": "{fontFamilies.default}",
-              "fontWeight": "{fontWeights.400}",
-              "lineHeight": "{lineHeights.500}",
-              "fontSize": "{fontSizes.100}"
-            },
-            "type": "typography",
-            "description": "Style for the current page text"
           }
         }
       }

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -3516,6 +3516,32 @@
             "type": "typography"
           }
         }
+      },
+      "breadcrumb": {
+        "separator": {
+          "m": {
+            "value": {
+              "fontFamily": "{fontFamilies.default}",
+              "fontWeight": "{fontWeights.400}",
+              "lineHeight": "{lineHeights.500}",
+              "fontSize": "{fontSizes.100}"
+            },
+            "type": "typography",
+            "description": "Style for the slash forward character that separates the breadcrumbs"
+          }
+        },
+        "currentPage": {
+          "m": {
+            "value": {
+              "fontFamily": "{fontFamilies.default}",
+              "fontWeight": "{fontWeights.400}",
+              "lineHeight": "{lineHeights.500}",
+              "fontSize": "{fontSizes.100}"
+            },
+            "type": "typography",
+            "description": "Style for the current page text"
+          }
+        }
       }
     },
     "opacity": {


### PR DESCRIPTION
add a breadcrumb category inside typography tokens + two tokens to be consumed by the breadcrumb component (for the slash-separator and the current page text).
<img width="260" alt="image" src="https://user-images.githubusercontent.com/43612504/194508060-a5d82ae0-d16f-49b0-9c27-26ffe2e91bcd.png">
