### PR TITLE
chore: update semantic release action to prevent updating

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -37,7 +37,7 @@ jobs:
           git-commit-gpgsign: true
 
       - name: Release package to public NPM registry
-        run: npx semantic-release --debug
+        run: npx --no-install semantic-release --debug
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
adds `no-install` flag to semantic-release step of workflow. This should stop it updating to latest which requires node 18 (this repo is on 16 currently)