### PR TITLE
chore: lock semantic release version to v19 in workflow

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -37,7 +37,7 @@ jobs:
           git-commit-gpgsign: true
 
       - name: Release package to public NPM registry
-        run: npx --no-install semantic-release --debug
+        run: npx semantic-release@19 --debug
         env:
           GITHUB_TOKEN: ${{ secrets.ADMIN_ACCESS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Locks semantic release to v19 in workflow as latest version requires node 18