### PR TITLE
feat(data): update tokens object to remove dashboard-colors property and rename dashboard themes

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -3778,6 +3778,10 @@
           "value": "rgba(255,255,255,0.8)",
           "type": "color",
           "description": "Reference only. Do not use in components."
+        },
+        "010": {
+          "value": "#FFFFFF1A",
+          "type": "color"
         }
       },
       "malachite": {
@@ -4293,300 +4297,232 @@
         "type": "other"
       }
     },
-    "dashboard-colors": {
-      "background": {
-        "surface": {
-          "value": "{origin-colors (reference only).yang.100}",
-          "type": "color"
-        },
-        "neutral": {
-          "value": "{origin-colors (reference only).yin.010}",
-          "type": "color"
-        }
-      },
-      "text": {
-        "primary": {
-          "value": "{origin-colors (reference only).yin.090}",
-          "type": "color"
-        },
-        "secondary": {
-          "value": "{origin-colors (reference only).yin.055}",
-          "type": "color"
-        }
-      },
-      "callout": {
-        "value": "{origin-colors (reference only).fuchsia.500}",
+    "background": {
+      "surface": {
+        "value": "{origin-colors (reference only).yang.100}",
         "type": "color"
       },
-      "comparative": {
-        "core": {
+      "neutral": {
+        "value": "{origin-colors (reference only).yin.010}",
+        "type": "color"
+      }
+    },
+    "text": {
+      "primary": {
+        "value": "{origin-colors (reference only).yin.090}",
+        "type": "color"
+      },
+      "secondary": {
+        "value": "{origin-colors (reference only).yin.055}",
+        "type": "color"
+      }
+    },
+    "callout": {
+      "value": "{origin-colors (reference only).fuchsia.500}",
+      "type": "color"
+    },
+    "comparative": {
+      "core": {
+        "fill-1": {
+          "value": "{origin-colors (reference only).malachite.100}",
+          "type": "color"
+        },
+        "fill-2": {
+          "value": "{origin-colors (reference only).malachite.400}",
+          "type": "color"
+        }
+      },
+      "neutral": {
+        "fill-1": {
+          "value": "{origin-colors (reference only).gray.100}",
+          "type": "color"
+        },
+        "fill-2": {
+          "value": "{origin-colors (reference only).gray.400}",
+          "type": "color"
+        }
+      },
+      "primary": {
+        "positive": {
           "fill-1": {
-            "value": "{origin-colors (reference only).malachite.100}",
+            "value": "{origin-colors (reference only).jade.100}",
             "type": "color"
           },
           "fill-2": {
-            "value": "{origin-colors (reference only).malachite.400}",
+            "value": "{origin-colors (reference only).jade.400}",
             "type": "color"
           }
         },
-        "neutral": {
+        "negative": {
           "fill-1": {
-            "value": "{origin-colors (reference only).gray.100}",
+            "value": "{origin-colors (reference only).amber.100}",
             "type": "color"
           },
           "fill-2": {
-            "value": "{origin-colors (reference only).gray.400}",
+            "value": "{origin-colors (reference only).amber.400}",
             "type": "color"
-          }
-        },
-        "primary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).jade.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).jade.400}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).amber.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).amber.400}",
-              "type": "color"
-            }
-          }
-        },
-        "secondary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).navy.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).navy.400}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).cherry.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).cherry.400}",
-              "type": "color"
-            }
-          }
-        },
-        "tertiary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).teal.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).teal.400}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).terra.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).terra.400}",
-              "type": "color"
-            }
           }
         }
       },
-      "divergent": {
-        "primary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).jade.200}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).jade.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).jade.600}",
-              "type": "color"
-            }
+      "secondary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).navy.100}",
+            "type": "color"
           },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).amber.200}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).amber.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).amber.600}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).navy.400}",
+            "type": "color"
           }
         },
-        "secondary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).navy.200}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).navy.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).navy.600}",
-              "type": "color"
-            }
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).cherry.100}",
+            "type": "color"
           },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).cherry.200}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).cherry.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).cherry.600}",
-              "type": "color"
-            }
-          }
-        },
-        "tertiary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).teal.200}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).teal.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).teal.600}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).terra.200}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).terra.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).terra.600}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).cherry.400}",
+            "type": "color"
           }
         }
       },
-      "gap": {
-        "core": {
-          "border": {
-            "value": "{origin-colors (reference only).malachite.700}",
+      "tertiary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).teal.100}",
             "type": "color"
           },
-          "fill": {
-            "value": "{origin-colors (reference only).malachite.100}",
-            "type": "color"
-          }
-        },
-        "neutral": {
-          "border": {
-            "value": "{origin-colors (reference only).gray.700}",
-            "type": "color"
-          },
-          "fill": {
-            "value": "{origin-colors (reference only).gray.100}",
+          "fill-2": {
+            "value": "{origin-colors (reference only).teal.400}",
             "type": "color"
           }
         },
-        "primary": {
-          "positive": {
-            "border": {
-              "value": "{origin-colors (reference only).jade.700}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).jade.100}",
-              "type": "color"
-            }
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).terra.100}",
+            "type": "color"
           },
-          "negative": {
-            "border": {
-              "value": "{origin-colors (reference only).amber.700}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).amber.100}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).terra.400}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "divergent": {
+      "primary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).jade.200}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).jade.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).jade.600}",
+            "type": "color"
           }
         },
-        "secondary": {
-          "positive": {
-            "border": {
-              "value": "{origin-colors (reference only).navy.700}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).navy.100}",
-              "type": "color"
-            }
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).amber.200}",
+            "type": "color"
           },
-          "negative": {
-            "border": {
-              "value": "{origin-colors (reference only).cherry.700}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).cherry.100}",
-              "type": "color"
-            }
-          }
-        },
-        "tertiary": {
-          "positive": {
-            "border": {
-              "value": "{origin-colors (reference only).teal.600}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).teal.100}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).amber.400}",
+            "type": "color"
           },
-          "negative": {
-            "border": {
-              "value": "{origin-colors (reference only).terra.600}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).terra.100}",
-              "type": "color"
-            }
+          "fill-3": {
+            "value": "{origin-colors (reference only).amber.600}",
+            "type": "color"
           }
         }
       },
-      "progressive": {
+      "secondary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).navy.200}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).navy.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).navy.600}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).cherry.200}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).cherry.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).cherry.600}",
+            "type": "color"
+          }
+        }
+      },
+      "tertiary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).teal.200}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).teal.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).teal.600}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).terra.200}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).terra.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).terra.600}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "gap": {
+      "core": {
+        "border": {
+          "value": "{origin-colors (reference only).malachite.700}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).malachite.100}",
+          "type": "color"
+        }
+      },
+      "neutral": {
+        "border": {
+          "value": "{origin-colors (reference only).gray.700}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).gray.100}",
+          "type": "color"
+        }
+      },
+      "primary": {
         "positive": {
           "border": {
             "value": "{origin-colors (reference only).jade.700}",
@@ -4594,16 +4530,6 @@
           },
           "fill": {
             "value": "{origin-colors (reference only).jade.100}",
-            "type": "color"
-          }
-        },
-        "neutral": {
-          "border": {
-            "value": "{origin-colors (reference only).navy.700}",
-            "type": "color"
-          },
-          "fill": {
-            "value": "{origin-colors (reference only).navy.100}",
             "type": "color"
           }
         },
@@ -4618,241 +4544,317 @@
           }
         }
       },
-      "qualitative": {
-        "fill-1": {
-          "value": "{origin-colors (reference only).jade.500}",
+      "secondary": {
+        "positive": {
+          "border": {
+            "value": "{origin-colors (reference only).navy.700}",
+            "type": "color"
+          },
+          "fill": {
+            "value": "{origin-colors (reference only).navy.100}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "border": {
+            "value": "{origin-colors (reference only).cherry.700}",
+            "type": "color"
+          },
+          "fill": {
+            "value": "{origin-colors (reference only).cherry.100}",
+            "type": "color"
+          }
+        }
+      },
+      "tertiary": {
+        "positive": {
+          "border": {
+            "value": "{origin-colors (reference only).teal.600}",
+            "type": "color"
+          },
+          "fill": {
+            "value": "{origin-colors (reference only).teal.100}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "border": {
+            "value": "{origin-colors (reference only).terra.600}",
+            "type": "color"
+          },
+          "fill": {
+            "value": "{origin-colors (reference only).terra.100}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "progressive": {
+      "positive": {
+        "border": {
+          "value": "{origin-colors (reference only).jade.700}",
           "type": "color"
         },
-        "fill-2": {
-          "value": "{origin-colors (reference only).navy.300}",
-          "type": "color"
-        },
-        "fill-3": {
-          "value": "{origin-colors (reference only).teal.500}",
-          "type": "color"
-        },
-        "fill-4": {
-          "value": "{origin-colors (reference only).gray.300}",
-          "type": "color"
-        },
-        "fill-5": {
-          "value": "{origin-colors (reference only).amber.500}",
+        "fill": {
+          "value": "{origin-colors (reference only).jade.100}",
           "type": "color"
         }
       },
-      "sequential": {
-        "core": {
+      "neutral": {
+        "border": {
+          "value": "{origin-colors (reference only).navy.700}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).navy.100}",
+          "type": "color"
+        }
+      },
+      "negative": {
+        "border": {
+          "value": "{origin-colors (reference only).amber.700}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).amber.100}",
+          "type": "color"
+        }
+      }
+    },
+    "qualitative": {
+      "fill-1": {
+        "value": "{origin-colors (reference only).jade.500}",
+        "type": "color"
+      },
+      "fill-2": {
+        "value": "{origin-colors (reference only).navy.300}",
+        "type": "color"
+      },
+      "fill-3": {
+        "value": "{origin-colors (reference only).teal.500}",
+        "type": "color"
+      },
+      "fill-4": {
+        "value": "{origin-colors (reference only).gray.300}",
+        "type": "color"
+      },
+      "fill-5": {
+        "value": "{origin-colors (reference only).amber.500}",
+        "type": "color"
+      }
+    },
+    "sequential": {
+      "core": {
+        "fill-1": {
+          "value": "{origin-colors (reference only).malachite.700}",
+          "type": "color"
+        },
+        "fill-2": {
+          "value": "{origin-colors (reference only).malachite.600}",
+          "type": "color"
+        },
+        "fill-3": {
+          "value": "{origin-colors (reference only).malachite.500}",
+          "type": "color"
+        },
+        "fill-4": {
+          "value": "{origin-colors (reference only).malachite.400}",
+          "type": "color"
+        },
+        "fill-5": {
+          "value": "{origin-colors (reference only).malachite.300}",
+          "type": "color"
+        },
+        "fill-6": {
+          "value": "{origin-colors (reference only).malachite.200}",
+          "type": "color"
+        }
+      },
+      "neutral": {
+        "fill-1": {
+          "value": "{origin-colors (reference only).gray.700}",
+          "type": "color"
+        },
+        "fill-2": {
+          "value": "{origin-colors (reference only).gray.600}",
+          "type": "color"
+        },
+        "fill-3": {
+          "value": "{origin-colors (reference only).gray.500}",
+          "type": "color"
+        },
+        "fill-4": {
+          "value": "{origin-colors (reference only).gray.400}",
+          "type": "color"
+        },
+        "fill-5": {
+          "value": "{origin-colors (reference only).gray.300}",
+          "type": "color"
+        },
+        "fill-6": {
+          "value": "{origin-colors (reference only).gray.200}",
+          "type": "color"
+        }
+      },
+      "primary": {
+        "positive": {
           "fill-1": {
-            "value": "{origin-colors (reference only).malachite.700}",
+            "value": "{origin-colors (reference only).jade.700}",
             "type": "color"
           },
           "fill-2": {
-            "value": "{origin-colors (reference only).malachite.600}",
+            "value": "{origin-colors (reference only).jade.600}",
             "type": "color"
           },
           "fill-3": {
-            "value": "{origin-colors (reference only).malachite.500}",
+            "value": "{origin-colors (reference only).jade.500}",
             "type": "color"
           },
           "fill-4": {
-            "value": "{origin-colors (reference only).malachite.400}",
+            "value": "{origin-colors (reference only).jade.400}",
             "type": "color"
           },
           "fill-5": {
-            "value": "{origin-colors (reference only).malachite.300}",
+            "value": "{origin-colors (reference only).jade.300}",
             "type": "color"
           },
           "fill-6": {
-            "value": "{origin-colors (reference only).malachite.200}",
+            "value": "{origin-colors (reference only).jade.200}",
             "type": "color"
           }
         },
-        "neutral": {
+        "negative": {
           "fill-1": {
-            "value": "{origin-colors (reference only).gray.700}",
+            "value": "{origin-colors (reference only).amber.700}",
             "type": "color"
           },
           "fill-2": {
-            "value": "{origin-colors (reference only).gray.600}",
+            "value": "{origin-colors (reference only).amber.600}",
             "type": "color"
           },
           "fill-3": {
-            "value": "{origin-colors (reference only).gray.500}",
+            "value": "{origin-colors (reference only).amber.500}",
             "type": "color"
           },
           "fill-4": {
-            "value": "{origin-colors (reference only).gray.400}",
+            "value": "{origin-colors (reference only).amber.400}",
             "type": "color"
           },
           "fill-5": {
-            "value": "{origin-colors (reference only).gray.300}",
+            "value": "{origin-colors (reference only).amber.300}",
             "type": "color"
           },
           "fill-6": {
-            "value": "{origin-colors (reference only).gray.200}",
+            "value": "{origin-colors (reference only).amber.200}",
+            "type": "color"
+          }
+        }
+      },
+      "secondary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).navy.700}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).navy.600}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).navy.500}",
+            "type": "color"
+          },
+          "fill-4": {
+            "value": "{origin-colors (reference only).navy.400}",
+            "type": "color"
+          },
+          "fill-5": {
+            "value": "{origin-colors (reference only).navy.300}",
+            "type": "color"
+          },
+          "fill-6": {
+            "value": "{origin-colors (reference only).navy.200}",
             "type": "color"
           }
         },
-        "primary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).jade.700}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).jade.600}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).jade.500}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).jade.400}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).jade.300}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).jade.200}",
-              "type": "color"
-            }
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).cherry.700}",
+            "type": "color"
           },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).amber.700}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).amber.600}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).amber.500}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).amber.400}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).amber.300}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).amber.200}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).cherry.600}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).cherry.500}",
+            "type": "color"
+          },
+          "fill-4": {
+            "value": "{origin-colors (reference only).cherry.400}",
+            "type": "color"
+          },
+          "fill-5": {
+            "value": "{origin-colors (reference only).cherry.300}",
+            "type": "color"
+          },
+          "fill-6": {
+            "value": "{origin-colors (reference only).cherry.200}",
+            "type": "color"
+          }
+        }
+      },
+      "tertiary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).teal.700}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).teal.600}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).teal.500}",
+            "type": "color"
+          },
+          "fill-4": {
+            "value": "{origin-colors (reference only).teal.400}",
+            "type": "color"
+          },
+          "fill-5": {
+            "value": "{origin-colors (reference only).teal.300}",
+            "type": "color"
+          },
+          "fill-6": {
+            "value": "{origin-colors (reference only).teal.200}",
+            "type": "color"
           }
         },
-        "secondary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).navy.700}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).navy.600}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).navy.500}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).navy.400}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).navy.300}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).navy.200}",
-              "type": "color"
-            }
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).terra.700}",
+            "type": "color"
           },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).cherry.700}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).cherry.600}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).cherry.500}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).cherry.400}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).cherry.300}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).cherry.200}",
-              "type": "color"
-            }
-          }
-        },
-        "tertiary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).teal.700}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).teal.600}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).teal.500}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).teal.400}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).teal.300}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).teal.200}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).terra.600}",
+            "type": "color"
           },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).terra.700}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).terra.600}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).terra.500}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).terra.400}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).terra.300}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).terra.200}",
-              "type": "color"
-            }
+          "fill-3": {
+            "value": "{origin-colors (reference only).terra.500}",
+            "type": "color"
+          },
+          "fill-4": {
+            "value": "{origin-colors (reference only).terra.400}",
+            "type": "color"
+          },
+          "fill-5": {
+            "value": "{origin-colors (reference only).terra.300}",
+            "type": "color"
+          },
+          "fill-6": {
+            "value": "{origin-colors (reference only).terra.200}",
+            "type": "color"
           }
         }
       }
@@ -4869,303 +4871,235 @@
         "type": "other"
       }
     },
-    "dashboard-colors": {
-      "background": {
-        "surface": {
-          "value": "{origin-colors (reference only).gray.700}",
-          "type": "color"
-        },
-        "neutral": {
-          "value": "{origin-colors (reference only).yin.020}",
-          "type": "color"
-        }
-      },
-      "text": {
-        "primary": {
-          "value": "{origin-colors (reference only).yang.100}",
-          "type": "color"
-        },
-        "secondary": {
-          "value": "{origin-colors (reference only).yang.080}",
-          "type": "color"
-        }
-      },
-      "callout": {
-        "value": "{origin-colors (reference only).fuchsia.400}",
+    "background": {
+      "surface": {
+        "value": "{origin-colors (reference only).gray.800}",
         "type": "color"
       },
-      "comparative": {
-        "core": {
+      "neutral": {
+        "value": "{origin-colors (reference only).yang.010}",
+        "type": "color"
+      }
+    },
+    "text": {
+      "primary": {
+        "value": "{origin-colors (reference only).yang.100}",
+        "type": "color"
+      },
+      "secondary": {
+        "value": "{origin-colors (reference only).yang.080}",
+        "type": "color"
+      }
+    },
+    "callout": {
+      "value": "{origin-colors (reference only).fuchsia.400}",
+      "type": "color"
+    },
+    "comparative": {
+      "core": {
+        "fill-1": {
+          "value": "{origin-colors (reference only).malachite.100}",
+          "type": "color"
+        },
+        "fill-2": {
+          "value": "{origin-colors (reference only).malachite.400}",
+          "type": "color"
+        }
+      },
+      "neutral": {
+        "fill-1": {
+          "value": "{origin-colors (reference only).gray.100}",
+          "type": "color"
+        },
+        "fill-2": {
+          "value": "{origin-colors (reference only).gray.400}",
+          "type": "color"
+        }
+      },
+      "primary": {
+        "positive": {
           "fill-1": {
-            "value": "{origin-colors (reference only).malachite.100}",
+            "value": "{origin-colors (reference only).jade.100}",
             "type": "color"
           },
           "fill-2": {
-            "value": "{origin-colors (reference only).malachite.400}",
+            "value": "{origin-colors (reference only).jade.400}",
             "type": "color"
           }
         },
-        "neutral": {
+        "negative": {
           "fill-1": {
-            "value": "{origin-colors (reference only).gray.100}",
+            "value": "{origin-colors (reference only).amber.100}",
             "type": "color"
           },
           "fill-2": {
-            "value": "{origin-colors (reference only).gray.400}",
+            "value": "{origin-colors (reference only).amber.400}",
             "type": "color"
-          }
-        },
-        "primary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).jade.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).jade.400}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).amber.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).amber.400}",
-              "type": "color"
-            }
-          }
-        },
-        "secondary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).navy.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).navy.400}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).cherry.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).cherry.400}",
-              "type": "color"
-            }
-          }
-        },
-        "tertiary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).teal.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).teal.400}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).terra.100}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).terra.400}",
-              "type": "color"
-            }
           }
         }
       },
-      "divergent": {
-        "primary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).jade.050}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).jade.200}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).jade.400}",
-              "type": "color"
-            }
+      "secondary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).navy.100}",
+            "type": "color"
           },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).amber.050}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).amber.200}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).amber.400}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).navy.400}",
+            "type": "color"
           }
         },
-        "secondary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).navy.050}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).navy.200}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).navy.400}",
-              "type": "color"
-            }
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).cherry.100}",
+            "type": "color"
           },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).cherry.050}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).cherry.200}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).cherry.400}",
-              "type": "color"
-            }
-          }
-        },
-        "tertiary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).teal.050}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).teal.200}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).teal.400}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).terra.050}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).terra.200}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).terra.400}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).cherry.400}",
+            "type": "color"
           }
         }
       },
-      "gap": {
-        "core": {
-          "border": {
-            "value": "{origin-colors (reference only).malachite.600}",
+      "tertiary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).teal.100}",
             "type": "color"
           },
-          "fill": {
-            "value": "{origin-colors (reference only).malachite.050}",
-            "type": "color"
-          }
-        },
-        "neutral": {
-          "border": {
-            "value": "{origin-colors (reference only).gray.600}",
-            "type": "color"
-          },
-          "fill": {
-            "value": "{origin-colors (reference only).gray.050}",
+          "fill-2": {
+            "value": "{origin-colors (reference only).teal.400}",
             "type": "color"
           }
         },
-        "primary": {
-          "positive": {
-            "border": {
-              "value": "{origin-colors (reference only).jade.600}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).jade.050}",
-              "type": "color"
-            }
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).terra.100}",
+            "type": "color"
           },
-          "negative": {
-            "border": {
-              "value": "{origin-colors (reference only).amber.600}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).amber.050}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).terra.400}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "divergent": {
+      "primary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).jade.050}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).jade.200}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).jade.400}",
+            "type": "color"
           }
         },
-        "secondary": {
-          "positive": {
-            "border": {
-              "value": "{origin-colors (reference only).navy.600}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).navy.050}",
-              "type": "color"
-            }
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).amber.050}",
+            "type": "color"
           },
-          "negative": {
-            "border": {
-              "value": "{origin-colors (reference only).cherry.600}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).cherry.050}",
-              "type": "color"
-            }
-          }
-        },
-        "tertiary": {
-          "positive": {
-            "border": {
-              "value": "{origin-colors (reference only).teal.600}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).teal.050}",
-              "type": "color"
-            }
+          "fill-2": {
+            "value": "{origin-colors (reference only).amber.200}",
+            "type": "color"
           },
-          "negative": {
-            "border": {
-              "value": "{origin-colors (reference only).terra.600}",
-              "type": "color"
-            },
-            "fill": {
-              "value": "{origin-colors (reference only).terra.050}",
-              "type": "color"
-            }
+          "fill-3": {
+            "value": "{origin-colors (reference only).amber.400}",
+            "type": "color"
           }
         }
       },
-      "progressive": {
+      "secondary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).navy.050}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).navy.200}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).navy.400}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).cherry.050}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).cherry.200}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).cherry.400}",
+            "type": "color"
+          }
+        }
+      },
+      "tertiary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).teal.050}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).teal.200}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).teal.400}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).terra.050}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).terra.200}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).terra.400}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "gap": {
+      "core": {
+        "border": {
+          "value": "{origin-colors (reference only).malachite.600}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).malachite.050}",
+          "type": "color"
+        }
+      },
+      "neutral": {
+        "border": {
+          "value": "{origin-colors (reference only).gray.600}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).gray.050}",
+          "type": "color"
+        }
+      },
+      "primary": {
         "positive": {
           "border": {
-            "value": "{origin-colors (reference only).gray.000}",
+            "value": "{origin-colors (reference only).jade.600}",
             "type": "color"
           },
           "fill": {
@@ -5173,9 +5107,21 @@
             "type": "color"
           }
         },
-        "neutral": {
+        "negative": {
           "border": {
-            "value": "{origin-colors (reference only).gray.000}",
+            "value": "{origin-colors (reference only).amber.600}",
+            "type": "color"
+          },
+          "fill": {
+            "value": "{origin-colors (reference only).amber.050}",
+            "type": "color"
+          }
+        }
+      },
+      "secondary": {
+        "positive": {
+          "border": {
+            "value": "{origin-colors (reference only).navy.600}",
             "type": "color"
           },
           "fill": {
@@ -5185,250 +5131,304 @@
         },
         "negative": {
           "border": {
-            "value": "{origin-colors (reference only).gray.000}",
+            "value": "{origin-colors (reference only).cherry.600}",
             "type": "color"
           },
           "fill": {
+            "value": "{origin-colors (reference only).cherry.050}",
+            "type": "color"
+          }
+        }
+      },
+      "tertiary": {
+        "positive": {
+          "border": {
+            "value": "{origin-colors (reference only).teal.600}",
+            "type": "color"
+          },
+          "fill": {
+            "value": "{origin-colors (reference only).teal.050}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "border": {
+            "value": "{origin-colors (reference only).terra.600}",
+            "type": "color"
+          },
+          "fill": {
+            "value": "{origin-colors (reference only).terra.050}",
+            "type": "color"
+          }
+        }
+      }
+    },
+    "progressive": {
+      "positive": {
+        "border": {
+          "value": "{origin-colors (reference only).gray.000}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).jade.050}",
+          "type": "color"
+        }
+      },
+      "neutral": {
+        "border": {
+          "value": "{origin-colors (reference only).gray.000}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).navy.050}",
+          "type": "color"
+        }
+      },
+      "negative": {
+        "border": {
+          "value": "{origin-colors (reference only).gray.000}",
+          "type": "color"
+        },
+        "fill": {
+          "value": "{origin-colors (reference only).amber.050}",
+          "type": "color"
+        }
+      }
+    },
+    "qualitative": {
+      "fill-1": {
+        "value": "{origin-colors (reference only).jade.400}",
+        "type": "color"
+      },
+      "fill-2": {
+        "value": "{origin-colors (reference only).navy.100}",
+        "type": "color"
+      },
+      "fill-3": {
+        "value": "{origin-colors (reference only).teal.400}",
+        "type": "color"
+      },
+      "fill-4": {
+        "value": "{origin-colors (reference only).gray.100}",
+        "type": "color"
+      },
+      "fill-5": {
+        "value": "{origin-colors (reference only).amber.400}",
+        "type": "color"
+      }
+    },
+    "sequential": {
+      "core": {
+        "fill-1": {
+          "value": "{origin-colors (reference only).malachite.500}",
+          "type": "color"
+        },
+        "fill-2": {
+          "value": "{origin-colors (reference only).malachite.400}",
+          "type": "color"
+        },
+        "fill-3": {
+          "value": "{origin-colors (reference only).malachite.300}",
+          "type": "color"
+        },
+        "fill-4": {
+          "value": "{origin-colors (reference only).malachite.200}",
+          "type": "color"
+        },
+        "fill-5": {
+          "value": "{origin-colors (reference only).malachite.100}",
+          "type": "color"
+        },
+        "fill-6": {
+          "value": "{origin-colors (reference only).malachite.050}",
+          "type": "color"
+        }
+      },
+      "neutral": {
+        "fill-1": {
+          "value": "{origin-colors (reference only).gray.500}",
+          "type": "color"
+        },
+        "fill-2": {
+          "value": "{origin-colors (reference only).gray.400}",
+          "type": "color"
+        },
+        "fill-3": {
+          "value": "{origin-colors (reference only).gray.300}",
+          "type": "color"
+        },
+        "fill-4": {
+          "value": "{origin-colors (reference only).gray.200}",
+          "type": "color"
+        },
+        "fill-5": {
+          "value": "{origin-colors (reference only).gray.100}",
+          "type": "color"
+        },
+        "fill-6": {
+          "value": "{origin-colors (reference only).gray.050}",
+          "type": "color"
+        }
+      },
+      "primary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).jade.500}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).jade.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).jade.300}",
+            "type": "color"
+          },
+          "fill-4": {
+            "value": "{origin-colors (reference only).jade.200}",
+            "type": "color"
+          },
+          "fill-5": {
+            "value": "{origin-colors (reference only).jade.100}",
+            "type": "color"
+          },
+          "fill-6": {
+            "value": "{origin-colors (reference only).jade.050}",
+            "type": "color"
+          }
+        },
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).amber.500}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).amber.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).amber.300}",
+            "type": "color"
+          },
+          "fill-4": {
+            "value": "{origin-colors (reference only).amber.200}",
+            "type": "color"
+          },
+          "fill-5": {
+            "value": "{origin-colors (reference only).amber.100}",
+            "type": "color"
+          },
+          "fill-6": {
             "value": "{origin-colors (reference only).amber.050}",
             "type": "color"
           }
         }
       },
-      "qualitative": {
-        "fill-1": {
-          "value": "{origin-colors (reference only).jade.400}",
-          "type": "color"
+      "secondary": {
+        "positive": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).navy.500}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).navy.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).navy.300}",
+            "type": "color"
+          },
+          "fill-4": {
+            "value": "{origin-colors (reference only).navy.200}",
+            "type": "color"
+          },
+          "fill-5": {
+            "value": "{origin-colors (reference only).navy.100}",
+            "type": "color"
+          },
+          "fill-6": {
+            "value": "{origin-colors (reference only).navy.050}",
+            "type": "color"
+          }
         },
-        "fill-2": {
-          "value": "{origin-colors (reference only).navy.100}",
-          "type": "color"
-        },
-        "fill-3": {
-          "value": "{origin-colors (reference only).teal.400}",
-          "type": "color"
-        },
-        "fill-4": {
-          "value": "{origin-colors (reference only).gray.100}",
-          "type": "color"
-        },
-        "fill-5": {
-          "value": "{origin-colors (reference only).amber.400}",
-          "type": "color"
+        "negative": {
+          "fill-1": {
+            "value": "{origin-colors (reference only).cherry.500}",
+            "type": "color"
+          },
+          "fill-2": {
+            "value": "{origin-colors (reference only).cherry.400}",
+            "type": "color"
+          },
+          "fill-3": {
+            "value": "{origin-colors (reference only).cherry.300}",
+            "type": "color"
+          },
+          "fill-4": {
+            "value": "{origin-colors (reference only).cherry.200}",
+            "type": "color"
+          },
+          "fill-5": {
+            "value": "{origin-colors (reference only).cherry.100}",
+            "type": "color"
+          },
+          "fill-6": {
+            "value": "{origin-colors (reference only).cherry.050}",
+            "type": "color"
+          }
         }
       },
-      "sequential": {
-        "core": {
+      "tertiary": {
+        "positive": {
           "fill-1": {
-            "value": "{origin-colors (reference only).malachite.500}",
+            "value": "{origin-colors (reference only).teal.500}",
             "type": "color"
           },
           "fill-2": {
-            "value": "{origin-colors (reference only).malachite.400}",
+            "value": "{origin-colors (reference only).teal.400}",
             "type": "color"
           },
           "fill-3": {
-            "value": "{origin-colors (reference only).malachite.300}",
+            "value": "{origin-colors (reference only).teal.300}",
             "type": "color"
           },
           "fill-4": {
-            "value": "{origin-colors (reference only).malachite.200}",
+            "value": "{origin-colors (reference only).teal.200}",
             "type": "color"
           },
           "fill-5": {
-            "value": "{origin-colors (reference only).malachite.100}",
+            "value": "{origin-colors (reference only).teal.100}",
             "type": "color"
           },
           "fill-6": {
-            "value": "{origin-colors (reference only).malachite.050}",
+            "value": "{origin-colors (reference only).teal.050}",
             "type": "color"
           }
         },
-        "neutral": {
+        "negative": {
           "fill-1": {
-            "value": "{origin-colors (reference only).gray.500}",
+            "value": "{origin-colors (reference only).terra.500}",
             "type": "color"
           },
           "fill-2": {
-            "value": "{origin-colors (reference only).gray.400}",
+            "value": "{origin-colors (reference only).terra.400}",
             "type": "color"
           },
           "fill-3": {
-            "value": "{origin-colors (reference only).gray.300}",
+            "value": "{origin-colors (reference only).terra.300}",
             "type": "color"
           },
           "fill-4": {
-            "value": "{origin-colors (reference only).gray.200}",
+            "value": "{origin-colors (reference only).terra.200}",
             "type": "color"
           },
           "fill-5": {
-            "value": "{origin-colors (reference only).gray.100}",
+            "value": "{origin-colors (reference only).terra.100}",
             "type": "color"
           },
           "fill-6": {
-            "value": "{origin-colors (reference only).gray.050}",
+            "value": "{origin-colors (reference only).terra.050}",
             "type": "color"
-          }
-        },
-        "primary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).jade.500}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).jade.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).jade.300}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).jade.200}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).jade.100}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).jade.050}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).amber.500}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).amber.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).amber.300}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).amber.200}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).amber.100}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).amber.050}",
-              "type": "color"
-            }
-          }
-        },
-        "secondary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).navy.500}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).navy.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).navy.300}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).navy.200}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).navy.100}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).navy.050}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).cherry.500}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).cherry.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).cherry.300}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).cherry.200}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).cherry.100}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).cherry.050}",
-              "type": "color"
-            }
-          }
-        },
-        "tertiary": {
-          "positive": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).teal.500}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).teal.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).teal.300}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).teal.200}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).teal.100}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).teal.050}",
-              "type": "color"
-            }
-          },
-          "negative": {
-            "fill-1": {
-              "value": "{origin-colors (reference only).terra.500}",
-              "type": "color"
-            },
-            "fill-2": {
-              "value": "{origin-colors (reference only).terra.400}",
-              "type": "color"
-            },
-            "fill-3": {
-              "value": "{origin-colors (reference only).terra.300}",
-              "type": "color"
-            },
-            "fill-4": {
-              "value": "{origin-colors (reference only).terra.200}",
-              "type": "color"
-            },
-            "fill-5": {
-              "value": "{origin-colors (reference only).terra.100}",
-              "type": "color"
-            },
-            "fill-6": {
-              "value": "{origin-colors (reference only).terra.050}",
-              "type": "color"
-            }
           }
         }
       }
@@ -5822,6 +5822,484 @@
         "boxShadow.075": "S:37b52326a0a2de6019f2cbeb31312f26c9b7e234,",
         "boxShadow.090": "S:cfd1a0f57b8c6442b493acff9548bf515fb3250e,",
         "boxShadow.091": "S:fb5c738a7ceaf284bb7876b6353aa1d6d4f4f74f,"
+      }
+    },
+    {
+      "id": "0dd57a3b7c158a13c1b04e6e5efd7edeaf12155e",
+      "name": "DS dash-dark",
+      "selectedTokenSets": {
+        "base": "source",
+        "origin": "source",
+        "dashboard/darkMode": "enabled"
+      },
+      "$figmaStyleReferences": {
+        "dashboard-colors.background.surface": "S:b97746dfd13d29f480a7846ef5d914a4dccd6de6,",
+        "dashboard-colors.background.neutral": "S:16fdc793d512dcdc97d95e776a64de8915c95b7b,",
+        "dashboard-colors.text.primary": "S:85a55cb5da6b9d0db4a7ef86034cf913e2c640d5,",
+        "dashboard-colors.text.secondary": "S:fd06ce6a89b6d36549faefc1b8ec5deb77f9816a,",
+        "dashboard-colors.callout": "S:861abf958fc4efe66312d71e0967fc7cc7389e37,",
+        "dashboard-colors.comparative.core.fill-1": "S:7185ad1e52d643f83d9ebe07450ed0de5c4479ad,",
+        "dashboard-colors.comparative.core.fill-2": "S:ce8cb96383e5a57e1321be12df7bf7f27d9a30e2,",
+        "dashboard-colors.comparative.neutral.fill-1": "S:6f1079ab3bbf5ae21cb21cd940199fb5982d49cf,",
+        "dashboard-colors.comparative.neutral.fill-2": "S:266cb4ea9fb22da9d056e70877aa4907e71ed174,",
+        "dashboard-colors.comparative.primary.positive.fill-1": "S:997c3d2aaf2f96c31a0997cff2833d7120305499,",
+        "dashboard-colors.comparative.primary.positive.fill-2": "S:e48387f3900450994b1292c3b3d84f09de2e0618,",
+        "dashboard-colors.comparative.primary.negative.fill-1": "S:cdd9c469c5681f4105b86a7d476758f65b988135,",
+        "dashboard-colors.comparative.primary.negative.fill-2": "S:0a7ecc7e430782462c6dbed7e7aa10712ed84489,",
+        "dashboard-colors.comparative.secondary.positive.fill-1": "S:5507bff9ae96a032cb7cfa3e265ea3c0dbfb0449,",
+        "dashboard-colors.comparative.secondary.positive.fill-2": "S:c6252becdf7eaf50f6328bf184138335739ffe96,",
+        "dashboard-colors.comparative.secondary.negative.fill-1": "S:e6e3f9e772e5fdbb648080cf7dbcc26c65ec40bb,",
+        "dashboard-colors.comparative.secondary.negative.fill-2": "S:38869fddbb989e872bb1df989b94fe55c8a6f029,",
+        "dashboard-colors.comparative.tertiary.positive.fill-1": "S:6109ef94edb37955759d574249136c8da1fb07b3,",
+        "dashboard-colors.comparative.tertiary.positive.fill-2": "S:676bd6d8dbda3429c6536b453458ad13383a975a,",
+        "dashboard-colors.comparative.tertiary.negative.fill-1": "S:759daddfef9946d050c55309dfd2377fa417b255,",
+        "dashboard-colors.comparative.tertiary.negative.fill-2": "S:a2037ca436af5fb4d014afc3bc2b8242c4b32a73,",
+        "dashboard-colors.divergent.primary.positive.fill-1": "S:8b5b58715727debba88ea9e82626495969680c74,",
+        "dashboard-colors.divergent.primary.positive.fill-2": "S:d775b11200c560f578c6a3b2e52343f361785341,",
+        "dashboard-colors.divergent.primary.positive.fill-3": "S:c2c577f285ae830a5d59b2ca08fcf0f4960475f3,",
+        "dashboard-colors.divergent.primary.negative.fill-1": "S:6d0899102996d44331fb677837213872f604907c,",
+        "dashboard-colors.divergent.primary.negative.fill-2": "S:99b0b99c8f77f9dee0733e37f376cc4c56941805,",
+        "dashboard-colors.divergent.primary.negative.fill-3": "S:97f680fb65ebdbd3fe273366cb2aec2c7a87f725,",
+        "dashboard-colors.divergent.secondary.positive.fill-1": "S:fdcf2b9943f1c8d998be8b03c4b47cc4dc947aa1,",
+        "dashboard-colors.divergent.secondary.positive.fill-2": "S:abeafa66404adb8beec3083a9c516ff5f9a98ee6,",
+        "dashboard-colors.divergent.secondary.positive.fill-3": "S:eaaf59d07b4d40c19ea058a6ac318a2e9b4b3133,",
+        "dashboard-colors.divergent.secondary.negative.fill-1": "S:1431fa1324f38f3d5dcdd5e7c9dd459de5ea3f3e,",
+        "dashboard-colors.divergent.secondary.negative.fill-2": "S:723a67fe570e8dd0c0964ad605100bc28d3c2468,",
+        "dashboard-colors.divergent.secondary.negative.fill-3": "S:4125954ea70aab3d9db1dfa6d81350d94ec7518d,",
+        "dashboard-colors.divergent.tertiary.positive.fill-1": "S:45a2749b2c363d61665cb43b118f2e5e6c4c54df,",
+        "dashboard-colors.divergent.tertiary.positive.fill-2": "S:64f806b5b29d2805ea91d21e22cb8308893a0e9b,",
+        "dashboard-colors.divergent.tertiary.positive.fill-3": "S:702adb19fc2a2138ee7878af8aa3dca38952770a,",
+        "dashboard-colors.divergent.tertiary.negative.fill-1": "S:6601ae9d484abf493d3196ae9221aff1aa7d5525,",
+        "dashboard-colors.divergent.tertiary.negative.fill-2": "S:7c450d8b6168286ffe2ae31842692335a805790b,",
+        "dashboard-colors.divergent.tertiary.negative.fill-3": "S:8856fdb53f81f8d09122c335fe28f8d8ba929eef,",
+        "dashboard-colors.gap.core.border": "S:26036fa3f633ccd9c70560bc706956e8bb5952f0,",
+        "dashboard-colors.gap.core.fill": "S:6acbb2ec09543306802cdf0643c99f6edee57122,",
+        "dashboard-colors.gap.neutral.border": "S:308154974dd553cc0873cce0c31091ec37a9070d,",
+        "dashboard-colors.gap.neutral.fill": "S:805b534ae1e03f15ac6b6a6c73c16b217ad62680,",
+        "dashboard-colors.gap.primary.positive.border": "S:24c0c40a55e1c456d84e1c7775a5a691573aca98,",
+        "dashboard-colors.gap.primary.positive.fill": "S:54c65d8c9c33a81b978b4fdcea980b95faa5db17,",
+        "dashboard-colors.gap.primary.negative.border": "S:4d38602b1dd8f13ffad6689e6bed780690ac18e7,",
+        "dashboard-colors.gap.primary.negative.fill": "S:eb5726689ae3aed5c19129e9a07d3b5139b4dab7,",
+        "dashboard-colors.gap.secondary.positive.border": "S:f781984d58d81d959733f64391b767405cf37212,",
+        "dashboard-colors.gap.secondary.positive.fill": "S:3050c654d707a15b817e02a474ff34d51e9245c4,",
+        "dashboard-colors.gap.secondary.negative.border": "S:5922577c9a50fb0cb6cd30c7f28085bb25c1ab20,",
+        "dashboard-colors.gap.secondary.negative.fill": "S:7573d9218540704fec94d4cb483cd02aabc5502b,",
+        "dashboard-colors.gap.tertiary.positive.border": "S:8a7d05779180d59ae8f06bbf81b02f192ecc21b2,",
+        "dashboard-colors.gap.tertiary.positive.fill": "S:52d99262b71ca5cc6fd0cd4c3fc3a33e684241b4,",
+        "dashboard-colors.gap.tertiary.negative.border": "S:9c6fec1f595ebf29712509b52535a1b3f33a65c9,",
+        "dashboard-colors.gap.tertiary.negative.fill": "S:56f991dea582ca7c20e3dc1d636accf246929fb8,",
+        "dashboard-colors.progressive.positive.border": "S:950077b7ce4b23b19484b4592a695e8767151736,",
+        "dashboard-colors.progressive.positive.fill": "S:bd5a0c800c1d09063bfc6512165ba1433cd5af86,",
+        "dashboard-colors.progressive.neutral.border": "S:57972ff430bf90da76729ffa1962fd240de2b8b6,",
+        "dashboard-colors.progressive.neutral.fill": "S:fa1df4a2b34952bfa7e7804e0823002342789a96,",
+        "dashboard-colors.progressive.negative.border": "S:ce50222dedaf54a202a99fcf6e9fd4d7488b294c,",
+        "dashboard-colors.progressive.negative.fill": "S:e39aa4aae3cb60f7df7cc0ccfbd3ca2e91471be3,",
+        "dashboard-colors.qualitative.fill-1": "S:477f1bd4a351394f5badc1e2ad09bb4dae5787af,",
+        "dashboard-colors.qualitative.fill-2": "S:fd90f6fecc984394352bcdfea4972e5f1fee8dd7,",
+        "dashboard-colors.qualitative.fill-3": "S:bd3acdf7455895822608d5663267057aa19015a3,",
+        "dashboard-colors.qualitative.fill-4": "S:3922f7ca69deb2c6b5de981c062c357b9c7ccc25,",
+        "dashboard-colors.qualitative.fill-5": "S:252b9d568e5a791e2d730458b071e6c7977e8270,",
+        "dashboard-colors.sequential.core.fill-1": "S:74e49cf501f2bd1ff26c96e0f9f3eea6416f7d63,",
+        "dashboard-colors.sequential.core.fill-2": "S:d01c56fb5efd2ec625b29d80ac06acccab45ec41,",
+        "dashboard-colors.sequential.core.fill-3": "S:37798bd19fd7d1246445c8fce68ef181a5b46756,",
+        "dashboard-colors.sequential.core.fill-4": "S:ad729595f8ac4708ff3b488c94740c06b8fd448b,",
+        "dashboard-colors.sequential.core.fill-5": "S:d7c315da3a1f566c39bd0c3347822cd1ca167ea0,",
+        "dashboard-colors.sequential.core.fill-6": "S:9590fd9613c7ef764f2f3277925430395add34b1,",
+        "dashboard-colors.sequential.neutral.fill-1": "S:5a2bee37e9bb6113f3c5737750fdb3019da64826,",
+        "dashboard-colors.sequential.neutral.fill-2": "S:d063e90862f6b12114cad80aea14fe27bc8499a8,",
+        "dashboard-colors.sequential.neutral.fill-3": "S:074653f4cc9568d68ba79b184b4696e31fbd8678,",
+        "dashboard-colors.sequential.neutral.fill-4": "S:b50bb633ef2ba176babdf82c8d79eaa43626fa42,",
+        "dashboard-colors.sequential.neutral.fill-5": "S:cf658addc2f4bf7cc679cdbb439ee1dafd8d92cc,",
+        "dashboard-colors.sequential.neutral.fill-6": "S:6203cd4e615d3cfbc49aa8154c79dd47a47d0013,",
+        "dashboard-colors.sequential.primary.positive.fill-1": "S:5e8936cf556d967e75da0f1290319e4d93aabe27,",
+        "dashboard-colors.sequential.primary.positive.fill-2": "S:306e78fc6fb55b61607ce16f23cd3a0e4487bbcd,",
+        "dashboard-colors.sequential.primary.positive.fill-3": "S:ba18ebb91499a19400b28269c0f0d3e05a7327df,",
+        "dashboard-colors.sequential.primary.positive.fill-4": "S:61541068cfa1edacba7985a73fcb6b6b5767583b,",
+        "dashboard-colors.sequential.primary.positive.fill-5": "S:deef728692d1d38f54c6175c560dd8d47b94b6c8,",
+        "dashboard-colors.sequential.primary.positive.fill-6": "S:9f27a3cd70336fee69a999de833e37569d6d08f1,",
+        "dashboard-colors.sequential.primary.negative.fill-1": "S:8fbbca5876c84f1ace7254dc21770d23dc90fa9c,",
+        "dashboard-colors.sequential.primary.negative.fill-2": "S:90383728a9325cc5c17286a4e0c0662d16d7f7c1,",
+        "dashboard-colors.sequential.primary.negative.fill-3": "S:b64c303ff33bb8d642fa95d8a7e6e943a2ab77d4,",
+        "dashboard-colors.sequential.primary.negative.fill-4": "S:335dd3ab65d7314cca3cd9ddf840853094440a7c,",
+        "dashboard-colors.sequential.primary.negative.fill-5": "S:878bed9072a2d273f20d78b8016f04fc94d4b486,",
+        "dashboard-colors.sequential.primary.negative.fill-6": "S:5fefcb8aed94a80c9dfd4a94ba79f0561e918463,",
+        "dashboard-colors.sequential.secondary.positive.fill-1": "S:d757870e76d4e8b88c0a1addc76ed4c562424b17,",
+        "dashboard-colors.sequential.secondary.positive.fill-2": "S:8ada21bd62553b371fda03ebddc8dacf00dea10e,",
+        "dashboard-colors.sequential.secondary.positive.fill-3": "S:a3de0c1daa031f39ca30ef248147618d694b73cd,",
+        "dashboard-colors.sequential.secondary.positive.fill-4": "S:96575e746b40e7a66d8bb47d737c782e35c74273,",
+        "dashboard-colors.sequential.secondary.positive.fill-5": "S:ff0301cdf1b54ee5e5052ec4d33a9bd6f761d4af,",
+        "dashboard-colors.sequential.secondary.positive.fill-6": "S:3d8d0824b43a853db15de70d43026f0b5b72e803,",
+        "dashboard-colors.sequential.secondary.negative.fill-1": "S:ca2739f649f995e73ac02f5a3a73a5a90223aad4,",
+        "dashboard-colors.sequential.secondary.negative.fill-2": "S:e333194c4ba2d6a7ea8e86b56f0875f6162cd151,",
+        "dashboard-colors.sequential.secondary.negative.fill-3": "S:77785347ce2d454d3c3227fb20521152b5c99f0a,",
+        "dashboard-colors.sequential.secondary.negative.fill-4": "S:ba766e0a29e783151bda0bfdc51731b25fadb2bb,",
+        "dashboard-colors.sequential.secondary.negative.fill-5": "S:c535ddcba53e158793f754c36ae7793986f4b91d,",
+        "dashboard-colors.sequential.secondary.negative.fill-6": "S:ef0abc69c8c24e2b7bbab9679a9587d840043019,",
+        "dashboard-colors.sequential.tertiary.positive.fill-1": "S:a29a7caf2edb1c1b8287ee5eb86155f36c08daec,",
+        "dashboard-colors.sequential.tertiary.positive.fill-2": "S:824c2a3c085139fa399c0eb21c147bec80d6ac4d,",
+        "dashboard-colors.sequential.tertiary.positive.fill-3": "S:93ff8c5fc10fcb1c9688b9bd8959eda6beb4bd8a,",
+        "dashboard-colors.sequential.tertiary.positive.fill-4": "S:0cb43fe92c9bcab12b511eb5ef441ddc4892860c,",
+        "dashboard-colors.sequential.tertiary.positive.fill-5": "S:8d76a080ef447ba9514b0ad870f5abe8ccf3db62,",
+        "dashboard-colors.sequential.tertiary.positive.fill-6": "S:17d183ead53db80f4db355bd01080357041f23d2,",
+        "dashboard-colors.sequential.tertiary.negative.fill-1": "S:75e34d2b7df8a3328c294183d003c23a4138c574,",
+        "dashboard-colors.sequential.tertiary.negative.fill-2": "S:290dc6c5f06ccac96a166ac5106d19408f013ef7,",
+        "dashboard-colors.sequential.tertiary.negative.fill-3": "S:85f6dc709bb91a13803442daaa4302c43d506deb,",
+        "dashboard-colors.sequential.tertiary.negative.fill-4": "S:5323c38ef9f20259a2fb31679cf866e611410c3f,",
+        "dashboard-colors.sequential.tertiary.negative.fill-5": "S:051b1efda2877d9c86a50fd04a4adef206b29d58,",
+        "dashboard-colors.sequential.tertiary.negative.fill-6": "S:227017b3d4cb93bbf40e2e8248e92716c460d476,",
+        "background.surface": "S:51c621710d854e2c4551e6789dcd2d9afbdc71b6,",
+        "background.neutral": "S:83d2888e09a414b15e839dc6e5f8912e23217c53,",
+        "text.primary": "S:9de8d45bf2f25eacba0c1d801203463f3b138916,",
+        "text.secondary": "S:c09c19a9cbd6bc64a3445561ed17e7a58e9381a2,",
+        "callout": "S:e41e8e32034d0863a87beab545b3fe304668e85a,",
+        "comparative.core.fill-1": "S:0c5cc55ebc9449469de5afed10a7ab85c94e02fe,",
+        "comparative.core.fill-2": "S:51d8a94931e9d2a4e9967377b4f6553c8c10914c,",
+        "comparative.neutral.fill-1": "S:76a6b8b9645f079c37f172172cd3ae4ae325c58e,",
+        "comparative.neutral.fill-2": "S:dcd3e2e4cf7a4e12f8a1f00ed0eb82a8ba013204,",
+        "comparative.primary.positive.fill-1": "S:957a2f1bf2a848de104770c9cfa259c15c452cd8,",
+        "comparative.primary.positive.fill-2": "S:defb7eeb7cbed0296de09d1d6077236188948432,",
+        "comparative.primary.negative.fill-1": "S:14902ac0b13ab32bc2b642afe93bc0e68fa6d5b5,",
+        "comparative.primary.negative.fill-2": "S:9f31123581e12394e4f08b1dc84c0d80a3acc070,",
+        "comparative.secondary.positive.fill-1": "S:a7fa54f99549d07d03b30d6561c763768c8f9687,",
+        "comparative.secondary.positive.fill-2": "S:9a8cd4bb47ec1b767c3e6a1319bb372a41f1fd21,",
+        "comparative.secondary.negative.fill-1": "S:6ca6a9185e4e9d3eaa7fa7432b49a6e442794925,",
+        "comparative.secondary.negative.fill-2": "S:54d1e547829c7a9e7f1bbd62a3ddce4f5acf5f8d,",
+        "comparative.tertiary.positive.fill-1": "S:2f1c4ec94e3281d3b76510d60622d9b6248ec742,",
+        "comparative.tertiary.positive.fill-2": "S:7467f5cc1799725b8c3ab3a0a7efb0a8ed1dfa66,",
+        "comparative.tertiary.negative.fill-1": "S:4e79bc530d7ff4860446c0a0fa3d88cb112c8d96,",
+        "comparative.tertiary.negative.fill-2": "S:9d3a18fbb7943c1e46275fb94c01827d10dcf0e8,",
+        "divergent.primary.positive.fill-1": "S:492248396d02e11ba4edfde3af64a93b7ee1674d,",
+        "divergent.primary.positive.fill-2": "S:9b43e3a051d190f848f8ffe974925ab98e710a28,",
+        "divergent.primary.positive.fill-3": "S:ece1f4f699e6a7b88bd57330619c5110cf85a0d5,",
+        "divergent.primary.negative.fill-1": "S:65fea7cfc3e3749cef00934d8b4a88fe56cc112b,",
+        "divergent.primary.negative.fill-2": "S:4f7d49264d5b60114c9ae67ccb9d2a34b0af27ae,",
+        "divergent.primary.negative.fill-3": "S:2eb55971bb1d20266f0d02ed35dd0b5a3850f728,",
+        "divergent.secondary.positive.fill-1": "S:aada86bbf0c3d26b0347349344889db1f81d6dcc,",
+        "divergent.secondary.positive.fill-2": "S:b3e94fb5f60876132f921894580c455558eb6ed1,",
+        "divergent.secondary.positive.fill-3": "S:e535cd0300ea8051f5d05e454e7918c113f98825,",
+        "divergent.secondary.negative.fill-1": "S:d221497c987bf6ffd1313350ac53c5668d369170,",
+        "divergent.secondary.negative.fill-2": "S:36ee2aeb6cebece2e7f094b823ebf026ccd61c08,",
+        "divergent.secondary.negative.fill-3": "S:217ff15c683a5b2c1529736daf7aad7bba72e922,",
+        "divergent.tertiary.positive.fill-1": "S:b8f09badaf54e3d8e5b8bcefcae33ab44ef987a6,",
+        "divergent.tertiary.positive.fill-2": "S:cbe72aff8fe5c9549c2e2a9488204ccf362bf4f6,",
+        "divergent.tertiary.positive.fill-3": "S:29c7553ce35447859d11da2482d08f886090dbcf,",
+        "divergent.tertiary.negative.fill-1": "S:a21e8571f8802b2610c418b2355bcb2d5f5bf55e,",
+        "divergent.tertiary.negative.fill-2": "S:a99be01c5dfafffeb0b975036644e24731ebec38,",
+        "divergent.tertiary.negative.fill-3": "S:65976dc7e9fe352b0e7084074d1cc79979430e76,",
+        "gap.core.border": "S:fdecf77ca8bf22f8427e29a3403ca8712f21399d,",
+        "gap.core.fill": "S:12339ca7ae581a5ca8ee17ba4248ad1fe5b104bd,",
+        "gap.neutral.border": "S:b81d6ce791e4e910d54ab04962078dfb71c98bc5,",
+        "gap.neutral.fill": "S:c2dec0d31e0f9ff93485cb15d0ac842bad41c52c,",
+        "gap.primary.positive.border": "S:b549b697e97ec350e6689cb638a69af9a518ecfc,",
+        "gap.primary.positive.fill": "S:8c24418264d0a2d3308571e710b8cd6a042eaf07,",
+        "gap.primary.negative.border": "S:c18fd67d14ba9d3a7b63ea1eb0d5bfea12f735d2,",
+        "gap.primary.negative.fill": "S:b8bc7027d457fc8585760e342d4e13138a1ae212,",
+        "gap.secondary.positive.border": "S:4224be767f30ab4750ec675376b4b402b2a6ee5f,",
+        "gap.secondary.positive.fill": "S:0db3e0746cbadebfc23feec6dd88bc428f7ebe18,",
+        "gap.secondary.negative.border": "S:f4a9fafe2cab5c555d0b73ca34683afaf1e03bb9,",
+        "gap.secondary.negative.fill": "S:69b5979b7ebe4a0b9390712459fdc32e6b9f6f23,",
+        "gap.tertiary.positive.border": "S:7d6a5a5419e3b59b8c00c19dd0efe925da6f752f,",
+        "gap.tertiary.positive.fill": "S:ceb5a5fc8bc2c41ee4c6c6d4729f3ddd5bb41ef1,",
+        "gap.tertiary.negative.border": "S:453e8474537c1dc95d3337dd87d3e321005f2ef3,",
+        "gap.tertiary.negative.fill": "S:df9960552c4fe6cfc668a39c925ba55665cab5d5,",
+        "progressive.positive.border": "S:e9ed45d4ab8a21973fa1097dc7a4c0b1cb887634,",
+        "progressive.positive.fill": "S:e9d9266d2a0548beedbbd69db0a06552634e1011,",
+        "progressive.neutral.border": "S:f73dbde566815e667cdd4e55221b44538fd69eb7,",
+        "progressive.neutral.fill": "S:508744bdcfd4d7538f2d9603f228affcf27855d7,",
+        "progressive.negative.border": "S:3317c0546a8cc91dd833143aca51e8e65e82fb55,",
+        "progressive.negative.fill": "S:5f61571fdd91cc983e1f247fd7ffc412534ff2cd,",
+        "qualitative.fill-1": "S:fbc6d334fbf572736b68a64c9549b61386edde0e,",
+        "qualitative.fill-2": "S:33f7b7601e9dfd51f6fb9704810392ed1d2ebfe6,",
+        "qualitative.fill-3": "S:1755f172338f6462dcf60d2d3cb75278814e6b6a,",
+        "qualitative.fill-4": "S:66038481ebdf8aee35c7473e0f7a835ae872e834,",
+        "qualitative.fill-5": "S:27438de9a3b47a18485e4829046cbacb717440b2,",
+        "sequential.core.fill-1": "S:2f46f97587ea57e518d197c3b9921685cc9f0622,",
+        "sequential.core.fill-2": "S:470daf046c71cf9250f27ae04641d9340e44d7f1,",
+        "sequential.core.fill-3": "S:9199f602f0d6b4f154689c78bd46a723ccde81b9,",
+        "sequential.core.fill-4": "S:30ea4637dc3d28df5da690bd7cc1d5a5ed8c959e,",
+        "sequential.core.fill-5": "S:a0599fae16dc64e9c302bad26ef50769470050cf,",
+        "sequential.core.fill-6": "S:a276579e440be4bb13df20ba11d0047cbf9b992c,",
+        "sequential.neutral.fill-1": "S:21c99b8c65f2e22507c7f0dbd5eda2315a5afdaa,",
+        "sequential.neutral.fill-2": "S:50167c236f4a649724b4cdb0d966d8731baf514c,",
+        "sequential.neutral.fill-3": "S:9231e39246098fc596a4828fa9266f9b2b28d116,",
+        "sequential.neutral.fill-4": "S:c973b9b5dbb5dc5c6cda6eabc524912c4fbebe04,",
+        "sequential.neutral.fill-5": "S:b8a2c1c4d9c36e93f058643812c965bd3c25ba68,",
+        "sequential.neutral.fill-6": "S:df685b2c0e09d4a655996608d5cd813e6c40eb0d,",
+        "sequential.primary.positive.fill-1": "S:6cecb2f3f3b02ee2627d37ac2810f584e8e40d93,",
+        "sequential.primary.positive.fill-2": "S:4e446ee85f7944b1a12fc823aca3b7395ab1b696,",
+        "sequential.primary.positive.fill-3": "S:26daff608c60f6973a3958caed374c45b6198ab6,",
+        "sequential.primary.positive.fill-4": "S:e14ccd005416b351013e232056c4c465632156d5,",
+        "sequential.primary.positive.fill-5": "S:ea3546d07a40a85cf1b29dbf7b78b31a875c82e3,",
+        "sequential.primary.positive.fill-6": "S:8c1844fe4d391bd5d5364decbe36af6b8c099edf,",
+        "sequential.primary.negative.fill-1": "S:1743ed19ab2a704cae5b2cc60404672356992148,",
+        "sequential.primary.negative.fill-2": "S:f907bf9449a8bb85c953b859932b0b46a10a7407,",
+        "sequential.primary.negative.fill-3": "S:8aee43e655ecee7b330d9ddb548372a6d9507946,",
+        "sequential.primary.negative.fill-4": "S:82f52d0350147609965c8a445e65eaf85d4d0529,",
+        "sequential.primary.negative.fill-5": "S:2428596dd37f6af6099654117f44a10372a4c08a,",
+        "sequential.primary.negative.fill-6": "S:057d99deb4781169279ac07dfc45ac7662417b3a,",
+        "sequential.secondary.positive.fill-1": "S:5947eccdefc5e43e0c473fb2b22e18567454dca4,",
+        "sequential.secondary.positive.fill-2": "S:9271ee091e1b38e06e6e8ab4912b7163f0f5b1c1,",
+        "sequential.secondary.positive.fill-3": "S:cb9339bff9e75b65b650a77262b337b920f31cb4,",
+        "sequential.secondary.positive.fill-4": "S:cb998a9d15bfb2735b3f1d9268c39f63e42b50cd,",
+        "sequential.secondary.positive.fill-5": "S:e142c0a5eb65b619fe19853a9d23eb77a757d495,",
+        "sequential.secondary.positive.fill-6": "S:b903d64665997bcbe55a78ac430e80f11e76ee7a,",
+        "sequential.secondary.negative.fill-1": "S:a3a01ba156346d68245911e14f697a047650d510,",
+        "sequential.secondary.negative.fill-2": "S:274a3820136993af7db70a0ffca7e23603314956,",
+        "sequential.secondary.negative.fill-3": "S:6a6d9ec2e14ea6c33cec753c28594b1c0d17a383,",
+        "sequential.secondary.negative.fill-4": "S:2b683d4316a1a9cfd93031444dd127379d4145b7,",
+        "sequential.secondary.negative.fill-5": "S:e29862b337d8041ad57bb5a348b288cb2da4d9c4,",
+        "sequential.secondary.negative.fill-6": "S:d7483e45500a6089426004ee670c3aa679424afa,",
+        "sequential.tertiary.positive.fill-1": "S:e4119d09714c169555749e4fd3c7508f5e339241,",
+        "sequential.tertiary.positive.fill-2": "S:baeb754bc3dcb7108ed0f843952ad58e6fbe45d4,",
+        "sequential.tertiary.positive.fill-3": "S:6f6dc68b451f4cf695bb97f0fa624e07d85cb9cb,",
+        "sequential.tertiary.positive.fill-4": "S:6dc32607b5e38bc0b7f0179c20f92ebd670a74aa,",
+        "sequential.tertiary.positive.fill-5": "S:aa2e467a4ba357df6caea06aa62fcdc62341b45c,",
+        "sequential.tertiary.positive.fill-6": "S:53285ce6cad57818e16a76a9bbee7ea64babb14a,",
+        "sequential.tertiary.negative.fill-1": "S:08a2272585ea73cc22fb3396be6336af54638d4c,",
+        "sequential.tertiary.negative.fill-2": "S:7d6d50d89a312b84b53a4639373873995100cebf,",
+        "sequential.tertiary.negative.fill-3": "S:31d2794fb7c34c269f44fd46fbec4458b3587151,",
+        "sequential.tertiary.negative.fill-4": "S:1077b68398082925822f986a33dd72ad3bf5c5ea,",
+        "sequential.tertiary.negative.fill-5": "S:05c5272426b1f2d79d3ae8934458f20198a39234,",
+        "sequential.tertiary.negative.fill-6": "S:19cb55cde8474f70a8a25cadf96e03a7bcbf4e97,"
+      }
+    },
+    {
+      "id": "8b5802d33b02d0ad8af51c53cf9136d140879652",
+      "name": "DS dash-light",
+      "selectedTokenSets": {
+        "base": "source",
+        "origin": "source",
+        "dashboard/lightMode": "enabled"
+      },
+      "$figmaStyleReferences": {
+        "dashboard-colors.background.surface": "S:6175de842da454a927b994f38590cad606e98fdd,",
+        "dashboard-colors.background.neutral": "S:3e118f83898b6621e8b81ac240d2a4a975efdd5e,",
+        "dashboard-colors.text.primary": "S:32b5489fd5bae16f3339e004fff20605bea2491b,",
+        "dashboard-colors.text.secondary": "S:5fddae8965d6a43a54b008a094cf80a06a7dd993,",
+        "dashboard-colors.callout": "S:1c48168ce64220b965031499644ba16158dfcebd,",
+        "dashboard-colors.comparative.core.fill-1": "S:3ae0e3edd654fd69daf4f39faecace056e65287f,",
+        "dashboard-colors.comparative.core.fill-2": "S:fe189784df188df9baa033b96a9f18e1892acb59,",
+        "dashboard-colors.comparative.neutral.fill-1": "S:dbbe982bd2ba9f9e8943fa107712743b2b19ccfa,",
+        "dashboard-colors.comparative.neutral.fill-2": "S:fec0889144554cbf0e006080a213e47fe3e49381,",
+        "dashboard-colors.comparative.primary.positive.fill-1": "S:41ccedcdfa88ffd2607be7f47faca52ad58ff417,",
+        "dashboard-colors.comparative.primary.positive.fill-2": "S:74f5f8b435018bd55b846d71e95c50862396249c,",
+        "dashboard-colors.comparative.primary.negative.fill-1": "S:f87ded6f89835be77d2e4149cb4178869314ea3b,",
+        "dashboard-colors.comparative.primary.negative.fill-2": "S:deecf1648ef7ecca2d35440c4e43a0bb2b55e04a,",
+        "dashboard-colors.comparative.secondary.positive.fill-1": "S:6dfd1a06bc5ae4501c96d94f1fba4169d1edeb43,",
+        "dashboard-colors.comparative.secondary.positive.fill-2": "S:20f2e069279b37ffa9b0520ac915a6fdd5f673ed,",
+        "dashboard-colors.comparative.secondary.negative.fill-1": "S:f32a2aa67e361303ad49c58224e7237c83bda7b9,",
+        "dashboard-colors.comparative.secondary.negative.fill-2": "S:6320470f8f12f0c14be16d8dd4d7d3a2dcbde148,",
+        "dashboard-colors.comparative.tertiary.positive.fill-1": "S:cbadf2cab68aec37b99a0282e09fa3ee720f6aa5,",
+        "dashboard-colors.comparative.tertiary.positive.fill-2": "S:fe191022f813c60ead5db9c75a954176c12c1448,",
+        "dashboard-colors.comparative.tertiary.negative.fill-1": "S:074f84156efcad0bfdda651955f328da38c5ad02,",
+        "dashboard-colors.comparative.tertiary.negative.fill-2": "S:0a5dbc85889a7aa9fa9cc18c697f5d332b861aa1,",
+        "dashboard-colors.divergent.primary.positive.fill-1": "S:a3e35ae52b46ea81b1115660573b90916d62ff18,",
+        "dashboard-colors.divergent.primary.positive.fill-2": "S:f429eb09fc7c0b2ad1d7865bed5ee6a89c4d05cd,",
+        "dashboard-colors.divergent.primary.positive.fill-3": "S:2005c8640dfcd5ac0ff96a15cbbe8341453cf280,",
+        "dashboard-colors.divergent.primary.negative.fill-1": "S:8741338c8d2517b4d1850942f32a0d61efceb3ac,",
+        "dashboard-colors.divergent.primary.negative.fill-2": "S:1d514368c95f99fa2223f9949b14b7a4e6915c72,",
+        "dashboard-colors.divergent.primary.negative.fill-3": "S:df694f92b58199f5c9073fdc870d0f69a678ebd5,",
+        "dashboard-colors.divergent.secondary.positive.fill-1": "S:775fa14295cc7e0ea63aca231c57792326512da0,",
+        "dashboard-colors.divergent.secondary.positive.fill-2": "S:deb630cee601dbaa642c790463fbc8c4f400996a,",
+        "dashboard-colors.divergent.secondary.positive.fill-3": "S:7697abecf8296d677a228a6ec1a2c6d851eafe6f,",
+        "dashboard-colors.divergent.secondary.negative.fill-1": "S:b7a62459f5833fb8e8ee6c08d7a4182fec5e8d74,",
+        "dashboard-colors.divergent.secondary.negative.fill-2": "S:60ba243b1203a69f9be4814bd2d1719f100015e3,",
+        "dashboard-colors.divergent.secondary.negative.fill-3": "S:8bdf7ddfdf5baad6883283b492c8663c2efc3bc1,",
+        "dashboard-colors.divergent.tertiary.positive.fill-1": "S:0886055b0bcd892bf9188538a70702e3006ee134,",
+        "dashboard-colors.divergent.tertiary.positive.fill-2": "S:73c4d52be9c51ddc1ec0e61a1a7bc19c995e401a,",
+        "dashboard-colors.divergent.tertiary.positive.fill-3": "S:299a1e2911ddff52c02cb970875c220906a94faa,",
+        "dashboard-colors.divergent.tertiary.negative.fill-1": "S:63d560f3afdfaf21885503f31e5647e5782eec4f,",
+        "dashboard-colors.divergent.tertiary.negative.fill-2": "S:d32e38d4ef535d054d66cd341ddee6ffbda28db4,",
+        "dashboard-colors.divergent.tertiary.negative.fill-3": "S:d6799114e4e3a21e3ea35a0b7a6cc2660a19ceb9,",
+        "dashboard-colors.gap.core.border": "S:0f294e72a3a69b59e0ce7e3388dd91e082cae1bd,",
+        "dashboard-colors.gap.core.fill": "S:5badce1c1a4f3253c44c4ebb00c9d56626e0dd2c,",
+        "dashboard-colors.gap.neutral.border": "S:5262e92f37632f29e00000f13cd4d32b3cb5d218,",
+        "dashboard-colors.gap.neutral.fill": "S:aaee7656c7e9a8758f20b8cecc73921a812418fb,",
+        "dashboard-colors.gap.primary.positive.border": "S:65bdc5cbba5bcf77e292dbe97d909c5fc7e993a2,",
+        "dashboard-colors.gap.primary.positive.fill": "S:96ded9c6095cb2ca5ea0822f8ad1e3ea89cbe9af,",
+        "dashboard-colors.gap.primary.negative.border": "S:f7bf31ca032c6cefa7f12dba223857219a9efb33,",
+        "dashboard-colors.gap.primary.negative.fill": "S:08bc6b25bf42c909ef0918dcacbcb3e387d47d55,",
+        "dashboard-colors.gap.secondary.positive.border": "S:ad32ee96749d7cc8c3b2b136030c237681859aea,",
+        "dashboard-colors.gap.secondary.positive.fill": "S:c7d96e0fd1bbf654e3ca6a93d88ef45dd2982cd6,",
+        "dashboard-colors.gap.secondary.negative.border": "S:0d1f98f591106091efcdd21fb678485bfa8a7ce3,",
+        "dashboard-colors.gap.secondary.negative.fill": "S:e24ddca40934d2025ca781adcc54a496c4b04676,",
+        "dashboard-colors.gap.tertiary.positive.border": "S:0db315e7078adebe4e54d4f258241637ae1b9d54,",
+        "dashboard-colors.gap.tertiary.positive.fill": "S:0dacf9e66b71ae58cbfc7c29adf5bed46e69cf2c,",
+        "dashboard-colors.gap.tertiary.negative.border": "S:834c69b8675b9f1528e9f27e4111ebc70354fac4,",
+        "dashboard-colors.gap.tertiary.negative.fill": "S:376cd7ce5e7ee47c075ede74ad0b40e941b65809,",
+        "dashboard-colors.progressive.positive.border": "S:f257866050783a07fa3a83ee2711e6b6a6271257,",
+        "dashboard-colors.progressive.positive.fill": "S:ee05b825fca68848ad065aa53576dd246ec6895a,",
+        "dashboard-colors.progressive.neutral.border": "S:ad83c4e39e67c73d50445b6a96f536de2e78dfc5,",
+        "dashboard-colors.progressive.neutral.fill": "S:5d575c5380384f95ac4f93c320f2c5d85760d9de,",
+        "dashboard-colors.progressive.negative.border": "S:7a977ffb3a8ef15fdf40890ac3e06169b4e60fbe,",
+        "dashboard-colors.progressive.negative.fill": "S:71cfabfdca297462360b4cfdc4f05438baf16257,",
+        "dashboard-colors.qualitative.fill-1": "S:491c8f310dbbbce9ddd6aaf94bef5d6c8b920218,",
+        "dashboard-colors.qualitative.fill-2": "S:4def042d631c921d0cbd7f9f28ae7d290e416487,",
+        "dashboard-colors.qualitative.fill-3": "S:c9d436fbeb05c29c8ff4f77538fd8ecc21f3bf2a,",
+        "dashboard-colors.qualitative.fill-4": "S:9e75dc5ef02ccaacd0b1c6e25c61be97fb716969,",
+        "dashboard-colors.qualitative.fill-5": "S:974a26c2660c95409b0d76717c12fccf0540aa40,",
+        "dashboard-colors.sequential.core.fill-1": "S:af64d8877e0aaa1024ea7670398d07fb915ca488,",
+        "dashboard-colors.sequential.core.fill-2": "S:2680fadbd8c0c4cd9208dbdb8cfbd09eec8f03bf,",
+        "dashboard-colors.sequential.core.fill-3": "S:fc99db9fd6aee163c9868a65e00abeebae340020,",
+        "dashboard-colors.sequential.core.fill-4": "S:11225315de989e970098b5bd658a67f3b6128080,",
+        "dashboard-colors.sequential.core.fill-5": "S:5a2644d4f9e55083ba385bb471f2ee0e11d8ebf3,",
+        "dashboard-colors.sequential.core.fill-6": "S:9603d99568982a0bef9e3aa9328b2f2c9c20d705,",
+        "dashboard-colors.sequential.neutral.fill-1": "S:2268d8dc940e80ee7ae35ebe08ec44248a161f8a,",
+        "dashboard-colors.sequential.neutral.fill-2": "S:b92148867fa04f8df3927baced43ee2c9735dab8,",
+        "dashboard-colors.sequential.neutral.fill-3": "S:23a55d6403d7c2a88cb1aea982d4c9becef4ee19,",
+        "dashboard-colors.sequential.neutral.fill-4": "S:1533a1615125b42a3e220064866faf746709941a,",
+        "dashboard-colors.sequential.neutral.fill-5": "S:d4fcdf755f7c786f2a03f9b24a8c1bc48757f1fd,",
+        "dashboard-colors.sequential.neutral.fill-6": "S:3db6faf4e68aec81e755abc73c543d5c2733e3d7,",
+        "dashboard-colors.sequential.primary.positive.fill-1": "S:945731d6d35ad4a729f7bb3a67026a8e3cd0a376,",
+        "dashboard-colors.sequential.primary.positive.fill-2": "S:e9b0fa7be6ef03672d704a4fc585dedfafbbafb9,",
+        "dashboard-colors.sequential.primary.positive.fill-3": "S:e60debd733115d60a2700df174fd00b94e63fb43,",
+        "dashboard-colors.sequential.primary.positive.fill-4": "S:27db723afe1d0db3409ab4ca83956805135b86d3,",
+        "dashboard-colors.sequential.primary.positive.fill-5": "S:84e873490c7c8c4cf502ddcf5a3cc9323035889e,",
+        "dashboard-colors.sequential.primary.positive.fill-6": "S:e6344e54119baa920d9c81ca370ff703f191fade,",
+        "dashboard-colors.sequential.primary.negative.fill-1": "S:c67298c9196443a56be4d7167eef688db8906b41,",
+        "dashboard-colors.sequential.primary.negative.fill-2": "S:7e0a9efd5cf934dea90a2395096e4225c6ca3302,",
+        "dashboard-colors.sequential.primary.negative.fill-3": "S:9f12feaa8bfd37e7685adacefc65e9c7590f2711,",
+        "dashboard-colors.sequential.primary.negative.fill-4": "S:08ef9f4d160c1082f5566f95c3c335d8d5b27c89,",
+        "dashboard-colors.sequential.primary.negative.fill-5": "S:85250a7b8e457e8b483864bc20a5bbf69a12c8d6,",
+        "dashboard-colors.sequential.primary.negative.fill-6": "S:0e5d38dc403b882a25262f42812f70f8e58eab52,",
+        "dashboard-colors.sequential.secondary.positive.fill-1": "S:7225758c12e53af413a5a4e1f82e7bbe6cbe8f86,",
+        "dashboard-colors.sequential.secondary.positive.fill-2": "S:be27a3e53e9dbf416d128cdc764e2fef28c6f063,",
+        "dashboard-colors.sequential.secondary.positive.fill-3": "S:12c5e73f1f1b833f1d1d0ab8a80aa181ae604433,",
+        "dashboard-colors.sequential.secondary.positive.fill-4": "S:1527be5fefda109ae6c759759c074db314b08964,",
+        "dashboard-colors.sequential.secondary.positive.fill-5": "S:68b64ecfde3fc2533c5ac6315ae67ab9b473e36b,",
+        "dashboard-colors.sequential.secondary.positive.fill-6": "S:698da2c8af895c8f320d8cb25d436a7c8ba97ecf,",
+        "dashboard-colors.sequential.secondary.negative.fill-1": "S:4974fc2b37d9a417a90808104fcd9607dbcab648,",
+        "dashboard-colors.sequential.secondary.negative.fill-2": "S:494e6d0c2b568265b709ee8d42def6fef0734072,",
+        "dashboard-colors.sequential.secondary.negative.fill-3": "S:595502e9f77b3e3c4af17cb76df80c47f148feda,",
+        "dashboard-colors.sequential.secondary.negative.fill-4": "S:4e236190ee7e3a5ce2431c0f168384a9b66940e9,",
+        "dashboard-colors.sequential.secondary.negative.fill-5": "S:9861a6ad2db2f1c687c17a78bb6a21aed6e91347,",
+        "dashboard-colors.sequential.secondary.negative.fill-6": "S:e3054a8bfc50206aa5388d3735a4ee159947e2bd,",
+        "dashboard-colors.sequential.tertiary.positive.fill-1": "S:36a0038c1d83f073ef820ed54b095759559a2724,",
+        "dashboard-colors.sequential.tertiary.positive.fill-2": "S:db34b697a4235bb8c82c0f9976b976927d2ff24c,",
+        "dashboard-colors.sequential.tertiary.positive.fill-3": "S:0fdf5bde7ddccd2b41ba7dc997ccd75519fd5e7e,",
+        "dashboard-colors.sequential.tertiary.positive.fill-4": "S:f4a7cbe6907abe59926cd8d71e0a525b3b5079c9,",
+        "dashboard-colors.sequential.tertiary.positive.fill-5": "S:8dd6ed00c7f097df18043019f23cd1de65d978bc,",
+        "dashboard-colors.sequential.tertiary.positive.fill-6": "S:773de724dd3f0e299785631cb449a47a91942da2,",
+        "dashboard-colors.sequential.tertiary.negative.fill-1": "S:539ea2cad50efef624a1a1d5da5555c5f5f8744f,",
+        "dashboard-colors.sequential.tertiary.negative.fill-2": "S:519e342ce097300bd98fdc77a22b9a6d921b4556,",
+        "dashboard-colors.sequential.tertiary.negative.fill-3": "S:9556110c20cb29765491ef69134b2256abcb78ce,",
+        "dashboard-colors.sequential.tertiary.negative.fill-4": "S:29db4b98562e1a0cbcc2a00ceea59ffef7cbe775,",
+        "dashboard-colors.sequential.tertiary.negative.fill-5": "S:03e01854f9e7198b73b39f7d45c78443452fb92b,",
+        "dashboard-colors.sequential.tertiary.negative.fill-6": "S:691fdf1920ccf22c27ddc282e16010f46f7827d5,",
+        "background.surface": "S:b9211b421ef3aed53bb2dd8e5b92ec2ba98bdf09,",
+        "background.neutral": "S:40e3f24e03ae208b5f809da4f931636b928d5596,",
+        "text.primary": "S:adbbdd8f274fb048c37160f02ec8f6f4050f3b1a,",
+        "text.secondary": "S:627fbf76ef8657c41ac1f3bd16249b685db2f9bd,",
+        "callout": "S:8c775b955d952ff441deb9f7b978ff9c08b33dce,",
+        "comparative.core.fill-1": "S:660942319a270c034815f239710d7edab98eff9b,",
+        "comparative.core.fill-2": "S:edb5f5a4dcc04f2cb0dda3e258f06de458a8a7e8,",
+        "comparative.neutral.fill-1": "S:65816d3212c0dcd32b46709cfc560a947ee842e0,",
+        "comparative.neutral.fill-2": "S:d5f9f236b8a47e33606c171ef1f73408ea16c707,",
+        "comparative.primary.positive.fill-1": "S:65fc1102d59ed93339e33ec7227fe6dca06188a7,",
+        "comparative.primary.positive.fill-2": "S:602f226e9a0be0fbe62bbb276c498eccdc001362,",
+        "comparative.primary.negative.fill-1": "S:9712d99bfd5c37ddb044d47d6536f70b0fec278d,",
+        "comparative.primary.negative.fill-2": "S:ac0719f260bfe3f1508ef2392c7a9b1bcd14b0b2,",
+        "comparative.secondary.positive.fill-1": "S:b8f13c5976f98b71ddf2cba360968c0f7760a229,",
+        "comparative.secondary.positive.fill-2": "S:c201d0621e640eb7de9e26460efe00d9c9d7560c,",
+        "comparative.secondary.negative.fill-1": "S:ca60749cbacad5a8fbc9c98263dc5d6bf0138157,",
+        "comparative.secondary.negative.fill-2": "S:dd899d1367b1848d09cce31fe7bab38843c4f1db,",
+        "comparative.tertiary.positive.fill-1": "S:625757945428d58a45b2d56e544e32404e4b28c6,",
+        "comparative.tertiary.positive.fill-2": "S:d3c00d3bd6db00685242e8105c268fb97d0bbbeb,",
+        "comparative.tertiary.negative.fill-1": "S:d812191aaa4a86fe3e05798baf32e530717ed0b9,",
+        "comparative.tertiary.negative.fill-2": "S:7b2b4369a13227477578f096e400805340edd4c8,",
+        "divergent.primary.positive.fill-1": "S:fd8db8a69be090f48bbc88c62112094c6c4196f3,",
+        "divergent.primary.positive.fill-2": "S:fc84f88a6331edac62175bcdfad7703866de5a77,",
+        "divergent.primary.positive.fill-3": "S:7e7662554271761baa2f0524cdf185e3619b4565,",
+        "divergent.primary.negative.fill-1": "S:54d2f5e91a6eaebdafaf851cc38737a03bea8e8a,",
+        "divergent.primary.negative.fill-2": "S:0524b46c9167d58a8e3cd5e358a21174290c17e3,",
+        "divergent.primary.negative.fill-3": "S:f69a8459a6bcea38240f21a34d09d23bacaf49f5,",
+        "divergent.secondary.positive.fill-1": "S:8d4c8f308a53c1d663a0b3325fe3dfda9a7dc31d,",
+        "divergent.secondary.positive.fill-2": "S:dce38e8b912e656a948c463591c0948905f87d8e,",
+        "divergent.secondary.positive.fill-3": "S:90d15fe8a2261436e0f8db3e76e8cd006a20d12d,",
+        "divergent.secondary.negative.fill-1": "S:c4c97ab2065519fe77f2cb224ee57886113050d8,",
+        "divergent.secondary.negative.fill-2": "S:25e579910cce92b354c36df1589964dd2575682b,",
+        "divergent.secondary.negative.fill-3": "S:7d089e3cef38aa5e36ce68b8a64774f8f5da58d8,",
+        "divergent.tertiary.positive.fill-1": "S:9fbc3512ee5e0a0c888f26d61f5545a454025cab,",
+        "divergent.tertiary.positive.fill-2": "S:990b31a0fd628274931399e1eecd7d7fb9db84b0,",
+        "divergent.tertiary.positive.fill-3": "S:ddd18de7fd36cfe6e37198b18bdfd33cf2b91732,",
+        "divergent.tertiary.negative.fill-1": "S:c3a22ca4d3ae04292e690abb795bf8beca0a8479,",
+        "divergent.tertiary.negative.fill-2": "S:3cd5d66ceb2ca9987e6805346b7b47bf4103675a,",
+        "divergent.tertiary.negative.fill-3": "S:32a2b1e4209663ea28f02b80979ade808ae0d73a,",
+        "gap.core.border": "S:6198e1fc992c82d970755eb68bf5be31bf4aa887,",
+        "gap.core.fill": "S:7b84b146d50e8e0e275aa94b8e8669094408d1be,",
+        "gap.neutral.border": "S:9edb91611d5b367e048745a98dcaf726d7e6648e,",
+        "gap.neutral.fill": "S:aac710078eb3023d6ba785479c00ef9581450804,",
+        "gap.primary.positive.border": "S:a64a6095edb376a296c6ef5d826ed2c6800f9a8f,",
+        "gap.primary.positive.fill": "S:461289373d27d37d23e61cef79b01185ba7dc4e6,",
+        "gap.primary.negative.border": "S:ae68a23f27ffa870bb3491d10fb35e9f2045a7d8,",
+        "gap.primary.negative.fill": "S:03cff78126493c03e1c2d4aece78cc4c77295cc5,",
+        "gap.secondary.positive.border": "S:d899ede8f51b96a80f32166610ed588e2a3b7eee,",
+        "gap.secondary.positive.fill": "S:d2bca43e2458dbeb6456e843094bf9f5c164843c,",
+        "gap.secondary.negative.border": "S:579cfca0ee4c89e351ff01efd4b8f9ee3148e528,",
+        "gap.secondary.negative.fill": "S:20cdce16c58ac1aad4d9e5cb6c52393903c48d32,",
+        "gap.tertiary.positive.border": "S:e1aee45600dddb4fafa632a2db879d8d7daae30c,",
+        "gap.tertiary.positive.fill": "S:3e2c01b84ab208dce15679c27db4572036deaab8,",
+        "gap.tertiary.negative.border": "S:961ef014017998ac6b16c64efe52d2d85b64f55f,",
+        "gap.tertiary.negative.fill": "S:932d4921984eb8ef4d9fd55c7ac4a41b03577102,",
+        "progressive.positive.border": "S:25ec1fdb4e793d15b6c94575110a304d3b05d27b,",
+        "progressive.positive.fill": "S:3425c6a3dcd4a665bbd8cd3f2156abee1afec243,",
+        "progressive.neutral.border": "S:e41f1daa9187328eb20f545c1f689b5e149dd7eb,",
+        "progressive.neutral.fill": "S:fb79b231be5e9136395b4546f648b6c82e8738c5,",
+        "progressive.negative.border": "S:0bf53240923991d0a0b0d9e45aa745696f182f4e,",
+        "progressive.negative.fill": "S:0c81f14ccc0849ee27e172a82c8c37400021762a,",
+        "qualitative.fill-1": "S:32a10ddabaf9adbb47f6044fb5ab99246990e535,",
+        "qualitative.fill-2": "S:b1233c4eb4618677a42be373345ae1bfa4b15391,",
+        "qualitative.fill-3": "S:97eef33b0d56d7dd165218cc1b63e9f0869ee39d,",
+        "qualitative.fill-4": "S:0eaa8d6408cf522429704b133aab2f33a8b00ba9,",
+        "qualitative.fill-5": "S:3368ee778bde70e0b3313486d192126230461429,",
+        "sequential.core.fill-1": "S:63adfdd47394725788839626067b1c2addb56858,",
+        "sequential.core.fill-2": "S:8eeb6414e1a7414498d1cb20ced77f183243c3d1,",
+        "sequential.core.fill-3": "S:4e84e2d7aa714d6fcd7b4e8155225eb036d2c711,",
+        "sequential.core.fill-4": "S:0cce2b3967ac6f2070c8973d6b5d8b1b38188c15,",
+        "sequential.core.fill-5": "S:c9f5912322d41406cef9890ba744faced1030e3c,",
+        "sequential.core.fill-6": "S:a1088a2a9dc66e378a098562bc6ec4d09f28a283,",
+        "sequential.neutral.fill-1": "S:02d17cdce863abc222da22732938cd609e207d80,",
+        "sequential.neutral.fill-2": "S:8b8c6fedef2e78bd9f6799341a3d0a3c835a221c,",
+        "sequential.neutral.fill-3": "S:c33039f1b6ea916cc35a461b5310c866ef552a1c,",
+        "sequential.neutral.fill-4": "S:c572cefd6a82381ebd12560a3fa4dec294a5b0d9,",
+        "sequential.neutral.fill-5": "S:5c1cf29aecf170a90ec4133e0ee9f3e1a0de8208,",
+        "sequential.neutral.fill-6": "S:2d3b23fb5616f9801ce27d0941feca2e83b384a2,",
+        "sequential.primary.positive.fill-1": "S:7507b580c3d73cd8177ec2d4b551a134df8585d4,",
+        "sequential.primary.positive.fill-2": "S:22a22daac9225b99f6e1b21f8db7ae9fc9c4ecf5,",
+        "sequential.primary.positive.fill-3": "S:7f542cf749b88c2d0432246d2854523cd07761e1,",
+        "sequential.primary.positive.fill-4": "S:bb55f9180059de6db5e73cc5fd75672087b476ce,",
+        "sequential.primary.positive.fill-5": "S:c229b65ab590abd9064d4949c55ebad4ca669008,",
+        "sequential.primary.positive.fill-6": "S:498e0e58a36c68a4af6bede0406dfb68a61296dd,",
+        "sequential.primary.negative.fill-1": "S:69c92e582d0d2a2aee064fff7b6d8ad117d43760,",
+        "sequential.primary.negative.fill-2": "S:cadcb23c5dd0601e456eaac515f53674d287feb4,",
+        "sequential.primary.negative.fill-3": "S:c89888c2b4aea10ee90d1fff0006686fb6a6c1c5,",
+        "sequential.primary.negative.fill-4": "S:22da83c1058b0cfe6583076f0bd9f7141bd0506f,",
+        "sequential.primary.negative.fill-5": "S:d590fc5d66aa92dfa996219a16ba8a0e8fd13fa4,",
+        "sequential.primary.negative.fill-6": "S:8ca3eeaad26c239f0b26528e9ff0cca511ecf475,",
+        "sequential.secondary.positive.fill-1": "S:9245a3993384b68224db1689d94e4aedcb079657,",
+        "sequential.secondary.positive.fill-2": "S:b6f3ea0627c89577945e84588d9f405f50df191e,",
+        "sequential.secondary.positive.fill-3": "S:0883cd0c1746dd427688b1873fb7daef9827ffd9,",
+        "sequential.secondary.positive.fill-4": "S:bd6a11e804cf43b2380575b5b6e69bd429991479,",
+        "sequential.secondary.positive.fill-5": "S:97b46e87ee71bc49b279a6baad62e0b7b0268dc4,",
+        "sequential.secondary.positive.fill-6": "S:b2abd590f7cdbb67363a9db87d20056a158bc769,",
+        "sequential.secondary.negative.fill-1": "S:72ab0f5e762bdfa67f69380ab032fd55de7fb3d1,",
+        "sequential.secondary.negative.fill-2": "S:d9d4041ab1b3a6a0463b996a9cb28cb1af10fd86,",
+        "sequential.secondary.negative.fill-3": "S:4b55191d0e35631b9cbff504d1ca30cb26b0971b,",
+        "sequential.secondary.negative.fill-4": "S:4659013fed26e218f6d22a8cdd92e4b639531289,",
+        "sequential.secondary.negative.fill-5": "S:b80153c41e56c0a9c04c7d87555b6702c1219922,",
+        "sequential.secondary.negative.fill-6": "S:b578b73bd20a24ecd92a8d1492fdbcaae40bbe74,",
+        "sequential.tertiary.positive.fill-1": "S:94b474bb451e8a7f1a9244ed294ff719dd639a5f,",
+        "sequential.tertiary.positive.fill-2": "S:f8a85e7fc8d5daa733ccee9b291e39caef5756d2,",
+        "sequential.tertiary.positive.fill-3": "S:936e040eb46eae281b2905196342da67454334e2,",
+        "sequential.tertiary.positive.fill-4": "S:340316fd9a243a765054f9ecb2c24924859790a8,",
+        "sequential.tertiary.positive.fill-5": "S:8461bb58ac13449729e726e4355dfe4dcdc6fd24,",
+        "sequential.tertiary.positive.fill-6": "S:a857c7a455c5bbed1c9feafa93149c214da873c6,",
+        "sequential.tertiary.negative.fill-1": "S:4a08ed373d150b05168405352df0f240bc7501cf,",
+        "sequential.tertiary.negative.fill-2": "S:e58097dcf731f8f972c5a895f4a29c207ba88d7c,",
+        "sequential.tertiary.negative.fill-3": "S:7ff86bed3dba700fcc34a58918ce8e2a2c26b4a9,",
+        "sequential.tertiary.negative.fill-4": "S:8615bb41192d9a0ccf6506bc2dbb2cdf8d21fb89,",
+        "sequential.tertiary.negative.fill-5": "S:2856cd2217b4577134637f6544e044467a2fa5e9,",
+        "sequential.tertiary.negative.fill-6": "S:b8b9896cbe818c97d9146e5485915e78fc522455,"
       }
     }
   ],


### PR DESCRIPTION
…
2) **Rename theme** DS dashboard-darkMode to DS dash-dark. 
3) **Rename theme** DS dashboard-lightMode to DS dash-light. 
4) **Add token** origin-colors (reference only).yang.010. 
5) **Change value** of dashboard-darkmode.background.surface from {origin-colors (reference only).gray.700} to {origin-colors (reference only).gray.800}. 
6) **Change value** of dashboard-darkmode.background.neutral from {origin-colors (reference only).yin.020} to {origin-colors (reference only).yang.010}

BREAKING CHANGE: The dasboard-colors property has been removed, the token values held within it have been moved to the root.