### PR TITLE
Divider on dark for Left Nav

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1356,6 +1356,11 @@
                 "type": "color",
                 "description": "Navigation bar bg-child (FY23)"
               },
+              "divider-on-dark": {
+                "value": "{colors.utility.yin.055}",
+                "type": "color",
+                "description": "Divider on dark for LeftNav (FY23)"
+              },
               "hover": {
                 "value": "{colors.action.major.500}",
                 "type": "color",


### PR DESCRIPTION
As discuss we create a left nav > divider token for now.
We will address this in the new tokens repo where we will have component specific tokens everywhere in the relative near future.