### PR TITLE
Style: new tokens

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -6764,7 +6764,12 @@
         "colors.action.minor.700": "S:2cf7331e6668fabf1b610e3895014f2fa3af02b2,",
         "colors.action.minor.gray.700": "S:0daa3a42362d71fde83d011e238da70f5994d20c,",
         "colors.components.leftnav.winter.standard.background-child": "S:200eea5dacb46245235caed5262689363f5a2591,",
-        "colors.components.leftnav.winter.standard.divider-on-dark": "S:47fb10a8f7f0de38371aeb5ee134cc651bd7700e,"
+        "colors.components.leftnav.winter.standard.divider-on-dark": "S:47fb10a8f7f0de38371aeb5ee134cc651bd7700e,",
+        "typography.loader.message.xs": "S:3392c087865a1331c7a9b90bf0ba5602e24d2a00,",
+        "typography.loader.message.s": "S:4a6572460940bd35cdd9b1e935834cc8a14545ae,",
+        "typography.loader.message.m": "S:a17fab112b1f11144f3e6dbd2a3add598464fa56,",
+        "typography.loader.message.l": "S:c84e8f784a534e8e7c232e59d001a6251c7c35bc,",
+        "typography.loader.message.xl": "S:eabf409acf6dda0aef4212f4b522a2e9c2f10dbf,"
       }
     }
   ],


### PR DESCRIPTION
Tokens synced to figma styles:
- colors.components.leftnav.winter.standard.background-child.
- colors.components.leftnav.winter.standard.divider-on-dark colors.action.minor.700 - used in action popover, dropdown (selected option), minor button, subtle button.
- sizing.550.
- spacing.035.
- typography.loader.message. xs/s/m/l/xl;  (Ring & Bar).
- Divider on light: standard: colors.utility.major.100
strong: colors.utility.major.500.
- Divider on dark: standard: colors.utility.major.200
strong: colors.utility.major.050.