### PR TITLE
docs(readme): Correct casing of @Sage scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,12 @@ To make use of the css variables, import them into your code like so:
 
 ```css
 /* Inside css */
-@import "~@Sage/design-tokens/css/<theme>.css";
+@import "~@sage/design-tokens/css/<theme>.css";
 ```
 
 ```js
 // For projects where you can import css files into JS
-import "@Sage/design-tokens/css/<theme>.css";
+import "@sage/design-tokens/css/<theme>.css";
 ```
 
 This will add the variables to the root element of the page.


### PR DESCRIPTION
When importing CSS using the documented path of `@import "@Sage/design-tokens/css/base.css";`, a [vite](https://vitejs.dev/) build results in an error:
> Unable to resolve `@import "@Sage/design-tokens/css/base.css"` from /home/runner/work/carbon-angular/carbon-angular/src/styles
[vite:css] [postcss] ENOENT: no such file or directory, open '@Sage/design-tokens/css/base.css'

This was due to a casing issue in case sensitive operating systems - it occurred in GitHub actions running under a linux environment. This change amends the documentation to be consistent by specifying a lower cased "@sage" scope.