### PR TITLE
feat(data): semantic.positive 500 and 600 darkened to meet WCAG requi…

### DIFF
--- a/data/tokens.json
+++ b/data/tokens.json
@@ -6791,7 +6791,8 @@
         "typography.loader.message.s": "S:4a6572460940bd35cdd9b1e935834cc8a14545ae,",
         "typography.loader.message.m": "S:a17fab112b1f11144f3e6dbd2a3add598464fa56,",
         "typography.loader.message.l": "S:c84e8f784a534e8e7c232e59d001a6251c7c35bc,",
-        "typography.loader.message.xl": "S:eabf409acf6dda0aef4212f4b522a2e9c2f10dbf,"
+        "typography.loader.message.xl": "S:eabf409acf6dda0aef4212f4b522a2e9c2f10dbf,",
+        "colors.semantic.positive.400": "S:96d6a2632dc536e74a6c463c78000812a0e611d0,"
       }
     }
   ],

--- a/data/tokens.json
+++ b/data/tokens.json
@@ -1051,12 +1051,14 @@
             "type": "color"
           },
           "500": {
-            "value": "#008A21",
-            "type": "color"
+            "value": "#00821F",
+            "type": "color",
+            "description": "Was #008A21 (not accessible on #F2F5F6)"
           },
           "600": {
-            "value": "#006e1a",
-            "type": "color"
+            "value": "#006819",
+            "type": "color",
+            "description": "Was #006E1A but 500 token was darkened, so 600 had to be darkened too."
           },
           "transparent": {
             "value": "$colors.transparent",


### PR DESCRIPTION
…rements on #F2F5F6. 500 token #008A21 darkened to #00821F. 600 also token darkened accordingly.