### PR TITLE
feat(frozen theme and profile): Add progress tracker tokens for frozen theme, and amend profile tokens, based on user feedback.

### DIFF
--- a/data/tokens/components/profile.json
+++ b/data/tokens/components/profile.json
@@ -76,7 +76,7 @@
         },
         "XXL": {
           "$type": "sizing",
-          "$value": "{global.size.micro.M} * 9",
+          "$value": "{global.size.micro.M} * 13",
           "$description": "XXL Portraits"
         }
       }

--- a/data/tokens/components/profile.json
+++ b/data/tokens/components/profile.json
@@ -76,7 +76,7 @@
         },
         "XXL": {
           "$type": "sizing",
-          "$value": "{global.size.micro.M} * 13",
+          "$value": "{global.size.micro.M} * 9",
           "$description": "XXL Portraits"
         }
       }

--- a/data/tokens/context/frozenproduct.json
+++ b/data/tokens/context/frozenproduct.json
@@ -422,18 +422,6 @@
   },
   "progress": {
     "color": {
-      "bg-default": {
-        "$type": "color",
-        "$value": "{modes.color.interactive.progress.frozen.bg-alt}"
-      },
-      "border-default": {
-        "$type": "color",
-        "$value": "{modes.color.generic.fg.frozen.soft}"
-      },
-      "fg-default": {
-        "$type": "color",
-        "$value": "{modes.color.interactive.monochrome.generic.frozen.active2}"
-      },
       "loader": {
         "bg-default": {
           "$type": "color",

--- a/data/tokens/context/frozenproduct.json
+++ b/data/tokens/context/frozenproduct.json
@@ -422,6 +422,18 @@
   },
   "progress": {
     "color": {
+      "bg-default": {
+        "$type": "color",
+        "$value": "{modes.color.interactive.progress.frozen.bg-alt}"
+      },
+      "border-default": {
+        "$type": "color",
+        "$value": "{modes.color.generic.fg.frozen.soft}"
+      },
+      "fg-default": {
+        "$type": "color",
+        "$value": "{modes.color.interactive.monochrome.generic.frozen.active2}"
+      },
       "loader": {
         "bg-default": {
           "$type": "color",

--- a/data/tokens/modes/dark.json
+++ b/data/tokens/modes/dark.json
@@ -340,6 +340,22 @@
             },
             "$type": "color",
             "$value": "{modes.color.generic.fg.nought}"
+          },
+          "frozen": {
+            "soft": {
+              "$extensions": {
+                "studio.tokens": {
+                  "modify": {
+                    "type": "mix",
+                    "value": "0.32",
+                    "space": "lch",
+                    "color": "{modes.color.modifier.contrastMore} "
+                  }
+                }
+              },
+              "$type": "color",
+              "$value": "{modes.color.generic.fg.nought}"
+            }
           }
         },
         "backdrop": {
@@ -771,6 +787,11 @@
                 "$type": "color",
                 "$value": "{modes.color.interactive.monochrome.generic.active}",
                 "$description": "Used within frozen table"
+              },
+              "active2": {
+                "$type": "color",
+                "$value": "{modes.color.interactive.monochrome.generic.active}",
+                "$description": "progress tracker"
               }
             }
           },
@@ -1011,6 +1032,10 @@
           },
           "frozen": {
             "bg": {
+              "$type": "color",
+              "$value": "{modes.color.interactive.progress.bg}"
+            },
+            "bg-alt": {
               "$type": "color",
               "$value": "{modes.color.interactive.progress.bg}"
             }

--- a/data/tokens/modes/dark.json
+++ b/data/tokens/modes/dark.json
@@ -340,22 +340,6 @@
             },
             "$type": "color",
             "$value": "{modes.color.generic.fg.nought}"
-          },
-          "frozen": {
-            "soft": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "mix",
-                    "value": "0.32",
-                    "space": "lch",
-                    "color": "{modes.color.modifier.contrastMore} "
-                  }
-                }
-              },
-              "$type": "color",
-              "$value": "{modes.color.generic.fg.nought}"
-            }
           }
         },
         "backdrop": {
@@ -787,11 +771,6 @@
                 "$type": "color",
                 "$value": "{modes.color.interactive.monochrome.generic.active}",
                 "$description": "Used within frozen table"
-              },
-              "active2": {
-                "$type": "color",
-                "$value": "{modes.color.interactive.monochrome.generic.active}",
-                "$description": "progress tracker"
               }
             }
           },
@@ -1032,10 +1011,6 @@
           },
           "frozen": {
             "bg": {
-              "$type": "color",
-              "$value": "{modes.color.interactive.progress.bg}"
-            },
-            "bg-alt": {
               "$type": "color",
               "$value": "{modes.color.interactive.progress.bg}"
             }

--- a/data/tokens/modes/light.json
+++ b/data/tokens/modes/light.json
@@ -341,6 +341,13 @@
             },
             "$type": "color",
             "$value": "{modes.color.generic.fg.nought}"
+          },
+          "frozen": {
+            "soft": {
+              "$type": "color",
+              "$value": "{modes.color.status.neutral.frozen.default}",
+              "$description": "frozen progress tracker border"
+            }
           }
         },
         "backdrop": {
@@ -807,6 +814,11 @@
                 "$type": "color",
                 "$value": "{primitives.colors.navy}",
                 "$description": "Used within frozen table"
+              },
+              "active2": {
+                "$type": "color",
+                "$value": "{modes.color.generic.fg.frozen.soft}",
+                "$description": "Frozen progress tracker"
               }
             }
           },
@@ -1059,6 +1071,21 @@
               },
               "$type": "color",
               "$value": "{primitives.colors.frozenJade}"
+            },
+            "bg-alt": {
+              "$extensions": {
+                "studio.tokens": {
+                  "modify": {
+                    "type": "mix",
+                    "value": "0.75",
+                    "space": "lch",
+                    "color": "{modes.color.modifier.contrastLess}"
+                  }
+                }
+              },
+              "$type": "color",
+              "$value": "{primitives.colors.navy}",
+              "$description": "progress tracker bg"
             }
           }
         }

--- a/data/tokens/modes/light.json
+++ b/data/tokens/modes/light.json
@@ -341,13 +341,6 @@
             },
             "$type": "color",
             "$value": "{modes.color.generic.fg.nought}"
-          },
-          "frozen": {
-            "soft": {
-              "$type": "color",
-              "$value": "{modes.color.status.neutral.frozen.default}",
-              "$description": "frozen progress tracker border"
-            }
           }
         },
         "backdrop": {
@@ -814,11 +807,6 @@
                 "$type": "color",
                 "$value": "{primitives.colors.navy}",
                 "$description": "Used within frozen table"
-              },
-              "active2": {
-                "$type": "color",
-                "$value": "{modes.color.generic.fg.frozen.soft}",
-                "$description": "Frozen progress tracker"
               }
             }
           },
@@ -1071,21 +1059,6 @@
               },
               "$type": "color",
               "$value": "{primitives.colors.frozenJade}"
-            },
-            "bg-alt": {
-              "$extensions": {
-                "studio.tokens": {
-                  "modify": {
-                    "type": "mix",
-                    "value": "0.75",
-                    "space": "lch",
-                    "color": "{modes.color.modifier.contrastLess}"
-                  }
-                }
-              },
-              "$type": "color",
-              "$value": "{primitives.colors.navy}",
-              "$description": "progress tracker bg"
             }
           }
         }


### PR DESCRIPTION
1. Add modes.color.generic.fg.frozen.soft to light and dark modes. 
2. Add modes.color.interactive.progress.frozen.bg-alt  to light and dark modes. 
3. Add modes.color.interactive.monochrome.generic.frozen.active2 to light and dark modes. 
4. Add progress.color to frozen-product theme, using the new frozen mode colors, for progress bar.