### PR TITLE
feat(Table border width): Update thick and add medium tokens.

### DIFF
--- a/data/tokens/components/table.json
+++ b/data/tokens/components/table.json
@@ -167,12 +167,17 @@
       "thin": {
         "$type": "borderWidth",
         "$value": "{global.borderwidth.XS}",
-        "$description": "Table border"
+        "$description": "Table border. Optional choice of cell border width."
+      },
+      "medium": {
+        "$type": "borderWidth",
+        "$value": "{global.borderwidth.S}",
+        "$description": "Header border for subtle. Optional choice of cell border width."
       },
       "thick": {
         "$type": "borderWidth",
-        "$value": "{global.borderwidth.S}",
-        "$description": "header border for subtle"
+        "$value": "{global.borderwidth.M}",
+        "$description": "Optional choice of cell border width."
       }
     },
     "space": {


### PR DESCRIPTION
- Update value of table.borderwidth.thick from 2px to 3px. 
- Add table.borderwidth.medium (2px). 
- A consequence of this is the need to replace existing application of table.borderwidth.thick with table.borderwidth.medium.