### PR TITLE
chore: add codeowners file to the repository

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+*                        @Sage/carbon-design-tokens
+
+# The Carbon Design Tokens team are responsible for reviewing Pull Requests
+# that contain any change modifying JS, TS or JSON files
+*.js                     @Sage/carbon-design-tokens
+*.ts                     @Sage/carbon-design-tokens
+*.json                   @Sage/carbon-design-tokens
+
+# Codeowners file changes must be approved by a Carbon Design Tokens
+# team member.
+.github/CODEOWNERS       @Sage/carbon-design-tokens


### PR DESCRIPTION
Adds a CODEOWNERS file to the repo.
I've intentionally been more explicit, wrt to the file extensions, than needed but there will likely be some future tweaks needed in the coming weeks so I have done it this way intentionally