### PR TITLE
chore: ensure workflows run on requests raised against rc-updates branch

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - rc-updates
       
 jobs:
   # Builds token library.

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - rc-updates
       
 jobs:
   run-linters:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - master
+      - rc-updates
 
 jobs:
   run-unit-tests:


### PR DESCRIPTION
adds `rc-updates` to branch patterns for build, lint and validation workflows so they run when branches target it