### PR TITLE
docs: fix broken contributing link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ It is possible to export design tokens to any format or language. If you need to
 
 ## Contributing
 
-If you would like to help contribute to this library, please read our [contributing documentation](./docs/CONTRIBUTING.md),
+If you would like to help contribute to this library, please read our [contributing documentation](./CONTRIBUTING.md),
 
 ## Licence
 


### PR DESCRIPTION
### Proposed behaviour

There's no CONTRIBUTING.md in docs. The file is actually CONTRIBUTING.md at the repo root.

### Current behaviour

Contributing link in README returns an error 404 because the link is incorrect.

### Design Tokens
<!-- If this PR includes design token changes, please indicate which of the following apply -->
- [ ] Token values updated
- [ ] New tokens added
- [ ] Tokens removed/renamed

<!-- If tokens were removed or renamed, please list them here for clarity -->
**Tokens removed/renamed:**
<!-- e.g., `color-primary` → `color-brand-primary` -->

### Checklist
<!-- Each PR should include the following -->
- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [x] Related docs have been updated if required

### QA
<!-- Testing performed by QA -->

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!--
How can a reviewer test this PR?
-->