### PR TITLE
feat(focus): add shadow focus tokens and update subtle hover colors

### DIFF
--- a/data/tokens/$themes.json
+++ b/data/tokens/$themes.json
@@ -1680,7 +1680,9 @@
       "profile.font.fluid.heading.ML": "S:16e7171a20fa111e0390ee78e5d035448bbe4dc5,",
       "profile.font.fluid.heading.L": "S:2ed359b0d5e4702315f349e6c3144ee373e2e8d0,",
       "profile.font.fluid.heading.XL": "S:48ff511bc28bf32d2ae34e3766afd4a998d6438a,",
-      "profile.font.fluid.heading.XXL": "S:d896fa617925c9d6afdfd99b078bccf027af56ec,"
+      "profile.font.fluid.heading.XXL": "S:d896fa617925c9d6afdfd99b078bccf027af56ec,",
+      "focus.shadow.default": "S:943c669b150123592247e82d8c3979f4dab11edb,",
+      "focus.shadow.inset": "S:a5da492a6f99e7e4ceb33123f9e9f0285f24430b,"
     },
     "selectedTokenSets": {
       "global/borderwidth": "source",

--- a/data/tokens/components/button.json
+++ b/data/tokens/components/button.json
@@ -375,7 +375,7 @@
         },
         "bg-hover": {
           "$type": "color",
-          "$value": "{mode.color.action.grayscale.hoverAlt}"
+          "$value": "{mode.color.generic.bg.delicate}"
         },
         "label-active": {
           "$type": "color",
@@ -435,7 +435,7 @@
         },
         "bg-hover": {
           "$type": "color",
-          "$value": "{mode.color.action.grayscale.hoverAlt}"
+          "$value": "{mode.color.generic.bg.delicate}"
         },
         "border-default": {
           "$type": "color",

--- a/data/tokens/components/container.json
+++ b/data/tokens/components/container.json
@@ -29,7 +29,7 @@
       },
       "bg-hover": {
         "$type": "color",
-        "$value": "{mode.color.action.grayscale.hoverAlt}",
+        "$value": "{mode.color.generic.bg.delicate}",
         "$description": "Used for accordion hov backgrounds "
       },
       "border-active": {

--- a/data/tokens/components/focus.json
+++ b/data/tokens/components/focus.json
@@ -33,6 +33,50 @@
         "$type": "color",
         "$value": "{mode.color.action.focus.inverse.txt}"
       }
+    },
+    "shadow": {
+      "default": {
+        "$type": "boxShadow",
+        "$value": [
+          {
+            "x": "0",
+            "y": "0",
+            "blur": "0",
+            "spread": "2",
+            "color": "{focus.borderalt}",
+            "type": "dropShadow"
+          },
+          {
+            "x": "0",
+            "y": "0",
+            "blur": "0",
+            "spread": "4",
+            "color": "{focus.border}",
+            "type": "dropShadow"
+          }
+        ]
+      },
+      "inset": {
+        "$type": "boxShadow",
+        "$value": [
+          {
+            "x": "0",
+            "y": "0",
+            "blur": "0",
+            "spread": "2",
+            "color": "{focus.border}",
+            "type": "innerShadow"
+          },
+          {
+            "x": "0",
+            "y": "0",
+            "blur": "0",
+            "spread": "4",
+            "color": "{focus.borderalt}",
+            "type": "innerShadow"
+          }
+        ]
+      }
     }
   }
 }

--- a/scripts/formats/outputRefForToken.ts
+++ b/scripts/formats/outputRefForToken.ts
@@ -34,12 +34,100 @@ const containsOperation = (value: string): boolean => {
 };
 
 /**
+ * Helper: Replace {references} with var(--kebab-case) in a string value
+ */
+const processReferences = (value: string): string => {
+  if (typeof value !== 'string') return String(value);
+  if (usesReferences(value)) {
+    return value.replace(
+      /\{([^}]+)\}/g,
+      (_, refPath) => `var(--${convertToKebabCase(refPath)})`
+    );
+  }
+  return value;
+};
+
+/**
+ * Helper: Add px unit to plain numeric strings
+ */
+const addPx = (value: string): string => {
+  if (usesReferences(value)) {
+    return processReferences(value);
+  }
+
+  if (Number(value) !== 0 && /^-?\d+(\.\d+)?$/.test(value)) {
+    return `${value}px`;
+  }
+
+  return value;
+};
+
+type BoxShadowTokenValue = Array<{
+  offsetX: string;
+  offsetY: string;
+  blur: string;
+  spread: string;
+  color: string;
+  type: string;
+}>;
+
+/**
+ * Helper: Convert a boxShadow array to a CSS box-shadow string
+ */
+const processBoxShadow = (
+  shadows: BoxShadowTokenValue
+
+): string => {
+  return shadows.map(({offsetX, offsetY, blur, spread, color, type}) => {
+    const prefix = type === 'innerShadow' ? 'inset ' : '';
+    const x = addPx(offsetX);
+    const y = addPx(offsetY);
+    const blurValue = addPx(blur);
+    const spreadValue = addPx(spread);
+    const colorValue = processReferences(color);
+
+    return `${prefix}${x} ${y} ${blurValue} ${spreadValue} ${colorValue}`;
+  }).join(', ');
+};
+
+type TypographyTokenValue = {
+  fontFamily: string;
+  fontWeight: string;
+  lineHeight: string;
+  fontSize: string;
+};
+
+/**
+ * Helper: Convert a typography object to a CSS font shorthand string
+ */
+const processTypography = (
+  typography: TypographyTokenValue
+): string => {
+  const fontWeight = processReferences(typography.fontWeight);
+  const fontSize = processReferences(typography.fontSize);
+  const lineHeight = processReferences(typography.lineHeight);
+  const fontFamily = processReferences(typography.fontFamily);
+  
+  return `${fontWeight} ${fontSize}/${lineHeight} ${fontFamily}`;
+};
+
+/**
  * Helper: Outputs a token value, replacing references with CSS variable references
  * @param originalValue The original value of the token, which may include references
  * @param token The design token object
  * @returns The processed value with CSS variable references where applicable
  */
-export const outputRefForToken = (originalValue: string, token: DesignToken): string => {
+export const outputRefForToken = (originalValue: string | TypographyTokenValue | BoxShadowTokenValue, token: DesignToken): string => {
+  // Handle boxShadow arrays
+  if (Array.isArray(originalValue)) {
+    return processBoxShadow(originalValue);
+  }
+
+  // Handle typography objects
+  if (typeof originalValue === 'object') {
+    return processTypography(originalValue);
+  }
+
   if (usesReferences(originalValue)) {
     if (originalValue.startsWith("linear-gradient(")) {
       const linearCSSValue = originalValue.replace(

--- a/scripts/style-dictionary.ts
+++ b/scripts/style-dictionary.ts
@@ -40,6 +40,7 @@ StyleDictionary.registerTransform({
 const groups = {
   css: [
     "custom/remove-comments",
+    "ts/shadow/innerShadow",
     "border/css/shorthand",
     "shadow/css/shorthand",
     "transition/css/shorthand",
@@ -55,6 +56,7 @@ const groups = {
   ],
   scss: [
     "custom/remove-comments",
+    "ts/shadow/innerShadow",
     "border/css/shorthand",
     "shadow/css/shorthand",
     "transition/css/shorthand", 


### PR DESCRIPTION
### Proposed behaviour
- Add focus shadows
- Update Accordion and button toggle hover states to consume storm group instead of black.

### Current behaviour
- Accordion and button toggles have a light gray hover state instead of light slate color.

### Design Tokens
<!-- If this PR includes design token changes, please indicate which of the following apply -->
- [x] Token values updated
- [x] New tokens added
- [ ] Tokens removed/renamed

<!-- If tokens were removed or renamed, please list them here for clarity -->
**Tokens removed/renamed:**
<!-- e.g., `color-primary` → `color-brand-primary` -->

### Checklist
<!-- Each PR should include the following -->
- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Related docs have been updated if required

### QA
<!-- Testing performed by QA -->

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!--
How can a reviewer test this PR?
-->