### PR TITLE
feat(dialog): add max width tokens for use on dialog component

### DIFF
--- a/data/tokens/components/container.json
+++ b/data/tokens/components/container.json
@@ -343,6 +343,25 @@
           "$value": "760",
           "$description": "Max width for single line of txt."
         }
+      },
+      "dialog": {
+        "maxwidth": {
+          "S": {
+            "$type": "sizing",
+            "$value": "540",
+            "$description": "max width for small dialog"
+          },
+          "M": {
+            "$type": "sizing",
+            "$value": "850",
+            "$description": "max width for medium dialog"
+          },
+          "L": {
+            "$type": "sizing",
+            "$value": "1080",
+            "$description": "max width for large dialog"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
### Proposed behaviour
Add missing max width tokens for consumption on the dialog modal

### Current behaviour
no tokens currently supplied

### Design Tokens
<!-- If this PR includes design token changes, please indicate which of the following apply -->
- [ ] Token values updated
- [x] New tokens added
- [ ] Tokens removed/renamed

<!-- If tokens were removed or renamed, please list them here for clarity -->
**Tokens removed/renamed:**
<!-- e.g., `color-primary` → `color-brand-primary` -->

### Checklist
<!-- Each PR should include the following -->
- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Related docs have been updated if required

