### PR TITLE
fix(format): support outputReferences in CommonJS exports formatter

### DIFF
--- a/scripts/formats/commonJSExports.ts
+++ b/scripts/formats/commonJSExports.ts
@@ -1,4 +1,5 @@
 import { Dictionary, DesignToken } from "style-dictionary/types";
+import { outputRefForToken } from "./outputRefForToken.js";
 
 /**
  * Custom format to output ensure commonJS variables output in the same format as ESM
@@ -6,10 +7,21 @@ import { Dictionary, DesignToken } from "style-dictionary/types";
  * @param dictionary The style dictionary object containing all tokens
  * @returns The processed commonJS variables in the same format as the ES6 output
  */
-export const formatCommonJSExports = ({dictionary}: {dictionary: Dictionary}) => {
+export const formatCommonJSExports = ({dictionary, options = {}}: {dictionary: Dictionary, options?: Record<string, any>}) => {
+  const { outputReferences = false } = options;
+
   const tokens = dictionary.allTokens
     .map((token: DesignToken) => {
-      return `module.exports.${token.name} = "${token.$value || token.value}";`;
+      const shouldOutputRef = typeof outputReferences === "function" ? outputReferences(token) : outputReferences;
+
+      if (shouldOutputRef) {
+        const originalValue = token["original"]?.value ?? token["original"]?.$value;
+        return `module.exports.${token.name} = "${outputRefForToken(originalValue, token)}";`;
+      }
+
+      const value = token.$value ?? token.value;
+      const serialized = typeof value === "object" ? JSON.stringify(value) : `"${value}"`;
+      return `module.exports.${token.name} = ${serialized};`;
     })
     .join('\n');
 

--- a/scripts/formats/commonJSWithRefs.ts
+++ b/scripts/formats/commonJSWithRefs.ts
@@ -12,7 +12,7 @@ export const outputCommonJSWithRefs = ({dictionary, options = {}}: {dictionary: 
 
     const tokens = dictionary.allTokens
       .map((token: DesignToken) => {
-        const originalValue = token["original"]?.value || token["original"]?.$value;
+        const originalValue = token["original"]?.value ?? token["original"]?.$value;
 
         if (outputReferences && token.name) {
           return `module.exports.${token.name} = "${outputRefForToken(originalValue, token)}";`;

--- a/scripts/formats/outputES6WithRefs.ts
+++ b/scripts/formats/outputES6WithRefs.ts
@@ -12,7 +12,7 @@ export const outputES6WithRefs = ({dictionary, options = {}}: {dictionary: Dicti
 
     const tokens = dictionary.allTokens
       .map((token: DesignToken) => {
-        const originalValue = token["original"]?.value || token["original"]?.$value;
+        const originalValue = token["original"]?.value ?? token["original"]?.$value;
         
         if (outputReferences && token.name) {
           return `export const ${token.name} = "${outputRefForToken(originalValue, token)}";`;

--- a/scripts/formats/outputJSONWithRefs.ts
+++ b/scripts/formats/outputJSONWithRefs.ts
@@ -12,7 +12,7 @@ export const outputJSONWithRefs = ({dictionary, options = {}}: {dictionary: Dict
     
     return JSON.stringify(
       dictionary.allTokens.reduce((acc: Record<string, any>, token: DesignToken) => {
-        const originalValue = token["original"].value || token["original"].$value;
+        const originalValue = token["original"].value ?? token["original"].$value;
 
         if (outputReferences && token.name) {
           acc[token.name] = outputRefForToken(originalValue, token);

--- a/tests/global-mode-tokens.test.ts
+++ b/tests/global-mode-tokens.test.ts
@@ -1,0 +1,187 @@
+import {
+  describe,
+  it,
+  expect,
+} from "vitest";
+import { resolve } from "path";
+import {
+  parseJSONFile,
+  parseCommonJSFile,
+  kebabToCamel
+} from "./utils/index.js";
+
+import { cwd } from "process";
+import { readFileSync } from "fs";
+
+const distPath = resolve(cwd(), "dist");
+
+// Helper to parse CommonJS file with object values
+function parseCommonJSWithObjects(filePath: string): Map<string, any> {
+  const content = readFileSync(filePath, 'utf-8');
+  const tokens = new Map<string, any>();
+  
+  // Split by module.exports lines to handle multi-line objects
+  const lines = content.split('\n').filter(line => line.includes('module.exports.'));
+  
+  lines.forEach(line => {
+    const match = line.match(/module\.exports\.(\w+)\s*=\s*(.+);/);
+    if (match && match[1] && match[2]) {
+      const key = match[1];
+      const valueStr = match[2];
+      
+      try {
+        // Try to parse as JSON if it starts with { or [
+        if (valueStr.startsWith('{') || valueStr.startsWith('[')) {
+          const value = JSON.parse(valueStr);
+          tokens.set(key, value);
+        } else if (valueStr.startsWith('"') && valueStr.endsWith('"')) {
+          // String value, remove quotes
+          tokens.set(key, valueStr.slice(1, -1));
+        } else {
+          // Raw value
+          tokens.set(key, valueStr);
+        }
+      } catch {
+        // If parsing fails, store as string
+        tokens.set(key, valueStr);
+      }
+    }
+  });
+  
+  return tokens;
+}
+
+describe("Global tokens", () => {
+  const globalJSON = parseJSONFile(resolve(distPath, "json/global.json"));
+  const globalCommonJS = parseCommonJSWithObjects(resolve(distPath, "js/common/global.js"));
+
+  it("should have consistent output between JSON and CommonJS formats", () => {
+    // Both should have the same keys (after case conversion)
+    globalJSON.forEach((_, jsonKey) => {
+      const jsKey = kebabToCamel(jsonKey);
+      expect(globalCommonJS.has(jsKey)).toBe(true);
+    });
+  });
+
+  it("should preserve numeric values including zero", () => {
+    // Borderwidth values should be preserved (includes "0" from borderwidthNone)
+    const borderwidthNone = globalCommonJS.get("globalBorderwidthNone");
+    expect(borderwidthNone).toBe("0");
+    
+    // Verify the borderwidth tokens exist and have correct values
+    expect(globalCommonJS.has("globalBorderwidthXs")).toBe(true);
+    expect(globalCommonJS.get("globalBorderwidthXs")).toBe("1px");
+  });
+
+  it("should serialize object tokens (like fonts) correctly", () => {
+    const fontToken = globalCommonJS.get("globalFontFluidHeadingS");
+    
+    // Should be an object, not a string
+    expect(typeof fontToken).toBe("object");
+    expect(fontToken).not.toBeNull();
+    
+    // Should have the expected properties
+    if (typeof fontToken === "object") {
+      expect(fontToken.fontFamily).toBe("Sage UI");
+      expect(fontToken.fontWeight).toBe("500");
+      expect(fontToken.lineHeight).toBe(1.25);
+      expect(fontToken.fontSize).toContain("clamp");
+    }
+  });
+
+  it("JSON should contain all global tokens", () => {
+    expect(globalJSON.size).toBeGreaterThan(0);
+    
+    // Check for key global token categories
+    const hasBreakpoints = Array.from(globalJSON.keys()).some(k => k.includes("Breakpoint"));
+    const hasFonts = Array.from(globalJSON.keys()).some(k => k.includes("Font"));
+    const hasSpace = Array.from(globalJSON.keys()).some(k => k.includes("Space"));
+    
+    expect(hasBreakpoints).toBe(true);
+    expect(hasFonts).toBe(true);
+    expect(hasSpace).toBe(true);
+  });
+});
+
+describe("Mode tokens (light/dark)", () => {
+  const modes = ["light", "dark"];
+
+  modes.forEach(mode => {
+    describe(`${mode} mode`, () => {
+      const modeJSON = parseJSONFile(resolve(distPath, `json/${mode}.json`));
+      const modeCommonJS = parseCommonJSWithObjects(resolve(distPath, `js/common/${mode}.js`));
+
+      it("should have mode-specific tokens", () => {
+        // Mode files should have tokens that start with 'mode'
+        const hasModeTokens = Array.from(modeJSON.keys()).some(k => k.includes("Color") || k.includes("Background"));
+        expect(hasModeTokens).toBe(true);
+      });
+
+      it("should have consistent output between JSON and CommonJS formats", () => {
+        // Spot check a few tokens
+        modeJSON.forEach((_, jsonKey) => {
+          if (typeof jsonKey === "string" && jsonKey.length > 0) {
+            const jsKey = kebabToCamel(jsonKey);
+            // Should exist in CommonJS (allowing for potential case differences)
+            const found = Array.from(modeCommonJS.keys()).some(k => k.toLowerCase() === jsKey.toLowerCase());
+            expect(found).toBe(true);
+          }
+        });
+      });
+
+      it("should have serializable values", () => {
+        modeCommonJS.forEach((value) => {
+          // All values should be either strings or objects
+          expect(typeof value === "string" || typeof value === "object").toBe(true);
+        });
+      });
+
+      it("should preserve falsy numeric values if present", () => {
+        // If any numeric 0 values exist, they should be preserved as "0" not undefined
+        modeCommonJS.forEach((value, key) => {
+          if (value === "0") {
+            expect(value).toBe("0");
+          }
+        });
+      });
+    });
+  });
+
+  it("light and dark modes should have different values for color tokens", () => {
+    const lightJSON = parseJSONFile(resolve(distPath, "json/light.json"));
+    const darkJSON = parseJSONFile(resolve(distPath, "json/dark.json"));
+
+    // Find a color token and verify light/dark differ
+    let foundDifference = false;
+    lightJSON.forEach((lightValue, key) => {
+      const darkValue = darkJSON.get(key);
+      if (darkValue && lightValue !== darkValue && key.includes("Color")) {
+        foundDifference = true;
+      }
+    });
+
+    // At least some mode tokens should differ between light and dark
+    expect(foundDifference).toBe(true);
+  });
+});
+
+describe("CommonJS exports format", () => {
+  it("should use module.exports.tokenName = value syntax", () => {
+    const content = readFileSync(resolve(distPath, "js/common/global.js"), "utf-8");
+    
+    // Should have module.exports pattern
+    expect(content).toMatch(/module\.exports\.\w+\s*=/);
+    
+    // Should not have nested object exports (each token is a separate export)
+    expect(content).not.toMatch(/module\.exports\s*=\s*\{/);
+  });
+
+  it("should handle multi-line values correctly", () => {
+    const globalCommonJS = parseCommonJSWithObjects(resolve(distPath, "js/common/global.js"));
+    
+    // Font object tokens may span multiple lines - verify they're parsed correctly
+    const fontToken = globalCommonJS.get("globalFontFluidHeadingS");
+    expect(fontToken).toBeDefined();
+    expect(typeof fontToken).toBe("object");
+  });
+});


### PR DESCRIPTION
### Proposed behaviour
<!--
A clear and concise description of what changes this PR makes. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

Adds support for an optional outputReferences setting in `commonJSExports.ts`

### Current behaviour
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

CommonJS export output did not handle token reference output behaviour consistently and could emit invalid values for object tokens

### Design Tokens
<!-- If this PR includes design token changes, please indicate which of the following apply -->
- [ ] Token values updated
- [ ] New tokens added
- [ ] Tokens removed/renamed

<!-- If tokens were removed or renamed, please list them here for clarity -->
**Tokens removed/renamed:**
<!-- e.g., `color-primary` → `color-brand-primary` -->

### Checklist
<!-- Each PR should include the following -->
- [x] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Related docs have been updated if required

### QA
<!-- Testing performed by QA -->

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!--
How can a reviewer test this PR?
-->