### PR TITLE
Add typography icon colors

### DIFF
--- a/data/tokens/components/page.json
+++ b/data/tokens/components/page.json
@@ -17,6 +17,42 @@
       "$type": "color",
       "$value": "{mode.color.generic.txt.severe}",
       "$description": "for headings, paragraph txt etc "
+    },
+    "txt": {
+      "blue": {
+        "$type": "color",
+        "$value": "{mode.color.status.info.default}"
+      },
+      "green": {
+        "$type": "color",
+        "$value": "{mode.color.status.positive.default}"
+      },
+      "orange": {
+        "$type": "color",
+        "$value": "{mode.color.status.warning.txt}"
+      },
+      "red": {
+        "$type": "color",
+        "$value": "{mode.color.status.negative.default}"
+      }
+    },
+    "icon": {
+      "blue": {
+        "$type": "color",
+        "$value": "{mode.color.status.info.default}"
+      },
+      "green": {
+        "$type": "color",
+        "$value": "{mode.color.status.positive.default}"
+      },
+      "orange": {
+        "$type": "color",
+        "$value": "{mode.color.status.warning.default}"
+      },
+      "red": {
+        "$type": "color",
+        "$value": "{mode.color.status.negative.default}"
+      }
     }
   }
 }

--- a/data/tokens/components/page.json
+++ b/data/tokens/components/page.json
@@ -18,40 +18,71 @@
       "$value": "{mode.color.generic.txt.severe}",
       "$description": "for headings, paragraph txt etc "
     },
-    "txt": {
-      "blue": {
+    "icon-alt": {
+      "$type": "color",
+      "$value": "{mode.color.generic.txt.moderate}"
+    },
+    "icon-default": {
+      "$type": "color",
+      "$value": "{mode.color.generic.txt.severe}",
+      "$description": "default color for standard icons"
+    },
+    "inverse": {
+      "txt-alt": {
         "$type": "color",
-        "$value": "{mode.color.status.info.default}"
+        "$value": "{mode.color.generic.txt.inverse.moderate}",
+        "$description": "for subheadings etc"
       },
-      "green": {
+      "txt-default": {
         "$type": "color",
-        "$value": "{mode.color.status.positive.default}"
+        "$value": "{mode.color.generic.txt.inverse.severe}",
+        "$description": "for headings, paragraph txt etc "
       },
-      "orange": {
+      "icon-alt": {
         "$type": "color",
-        "$value": "{mode.color.status.warning.txt}"
+        "$value": "{mode.color.generic.txt.inverse.moderate}"
       },
-      "red": {
+      "icon-default": {
         "$type": "color",
-        "$value": "{mode.color.status.negative.default}"
+        "$value": "{mode.color.generic.txt.inverse.severe}"
       }
     },
-    "icon": {
-      "blue": {
-        "$type": "color",
-        "$value": "{mode.color.status.info.default}"
+    "custom": {
+      "txt": {
+        "blue": {
+          "$type": "color",
+          "$value": "{mode.color.status.info.default}"
+        },
+        "green": {
+          "$type": "color",
+          "$value": "{mode.color.status.positive.default}"
+        },
+        "orange": {
+          "$type": "color",
+          "$value": "{mode.color.status.warning.txt}"
+        },
+        "red": {
+          "$type": "color",
+          "$value": "{mode.color.status.negative.default}"
+        }
       },
-      "green": {
-        "$type": "color",
-        "$value": "{mode.color.status.positive.default}"
-      },
-      "orange": {
-        "$type": "color",
-        "$value": "{mode.color.status.warning.default}"
-      },
-      "red": {
-        "$type": "color",
-        "$value": "{mode.color.status.negative.default}"
+      "icon": {
+        "blue": {
+          "$type": "color",
+          "$value": "{mode.color.status.info.default}"
+        },
+        "green": {
+          "$type": "color",
+          "$value": "{mode.color.status.positive.default}"
+        },
+        "orange": {
+          "$type": "color",
+          "$value": "{mode.color.status.warning.default}"
+        },
+        "red": {
+          "$type": "color",
+          "$value": "{mode.color.status.negative.default}"
+        }
       }
     }
   }


### PR DESCRIPTION
### Proposed behaviour
Add typography and icon specific color tokens located within the generic page file. Additional support for blue, red, orange and green added.
<img width="287" height="830" alt="Screenshot 2026-06-24 at 13 41 58" src="https://github.com/user-attachments/assets/44a79af7-1425-4c9d-b785-b76a4c4db50b" />

### Current behaviour
Currently only default color supported.
<img width="152" height="172" alt="Screenshot 2026-06-24 at 13 48 25" src="https://github.com/user-attachments/assets/89669365-e27c-4e9b-a85c-80715f017602" />

### Design Tokens
<!-- If this PR includes design token changes, please indicate which of the following apply -->
- [ ] Token values updated
- [x] New tokens added
- [ ] Tokens removed/renamed


### Checklist
<!-- Each PR should include the following -->
- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Related docs have been updated if required

### QA
<!-- Testing performed by QA -->

