### PR TITLE
feat: add mid layer to override font families and set a border radius scale

### DIFF
--- a/data/tokens/core.json
+++ b/data/tokens/core.json
@@ -1098,34 +1098,6 @@
         "$type": "paragraphSpacing",
         "$value": "{core.dimension.400}"
       }
-    },
-    "fontFamilies": {
-      "sage-icons": {
-        "$type": "fontFamilies",
-        "$value": "sage-icons"
-      },
-      "heading": {
-        "$type": "fontFamilies",
-        "$value": "Sage UI"
-      },
-      "subheading": {
-        "$type": "fontFamilies",
-        "$value": "Sage UI"
-      },
-      "body": {
-        "$type": "fontFamilies",
-        "$value": "Sage UI"
-      },
-      "component": {
-        "$type": "fontFamilies",
-        "$value": "Sage UI",
-        "$description": "Used in componentry such as tables, buttons, inputs etc."
-      },
-      "other": {
-        "$type": "fontFamilies",
-        "$value": "Open Sans",
-        "$description": "Fallback for when Sage fonts cannot load."
-      }
     }
   }
 }

--- a/data/tokens/global/font.json
+++ b/data/tokens/global/font.json
@@ -6,7 +6,7 @@
           "S": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.heading}",
+              "fontFamily": "{global.fontFamilies.heading}",
               "fontWeight": "{core.fontWeights.medium}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.fluid.step3}"
@@ -15,7 +15,7 @@
           "M": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.heading}",
+              "fontFamily": "{global.fontFamilies.heading}",
               "fontWeight": "{core.fontWeights.bold}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.fluid.step4}"
@@ -24,7 +24,7 @@
           "L": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.heading}",
+              "fontFamily": "{global.fontFamilies.heading}",
               "fontWeight": "{core.fontWeights.bold}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.fluid.step6}"
@@ -35,7 +35,7 @@
           "M": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.subheading}",
+              "fontFamily": "{global.fontFamilies.subheading}",
               "fontWeight": "{core.fontWeights.medium}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.fluid.step1}"
@@ -44,7 +44,7 @@
           "L": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.subheading}",
+              "fontFamily": "{global.fontFamilies.subheading}",
               "fontWeight": "{core.fontWeights.medium}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.fluid.step2}"
@@ -56,7 +56,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.subheading}",
+                "fontFamily": "{global.fontFamilies.subheading}",
                 "fontWeight": "{core.fontWeights.bold}",
                 "lineHeight": "{core.lineHeights.400}",
                 "fontSize": "{core.fontSize.fluid.step1}"
@@ -65,7 +65,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.subheading}",
+                "fontFamily": "{global.fontFamilies.subheading}",
                 "fontWeight": "{core.fontWeights.bold}",
                 "lineHeight": "{core.lineHeights.400}",
                 "fontSize": "{core.fontSize.fluid.step3}"
@@ -78,7 +78,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step0}",
@@ -88,7 +88,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step1}",
@@ -98,7 +98,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step2}",
@@ -110,7 +110,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step0}",
@@ -120,7 +120,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step1}",
@@ -130,7 +130,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step2}",
@@ -144,7 +144,7 @@
             "XS": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.stepMinus1}",
@@ -155,7 +155,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step0}",
@@ -166,7 +166,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step0}",
@@ -177,7 +177,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step1}",
@@ -190,7 +190,7 @@
             "XS": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.stepMinus1}",
@@ -201,7 +201,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step0}",
@@ -212,7 +212,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step0}",
@@ -223,7 +223,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step1}",
@@ -237,7 +237,7 @@
               "$type": "typography",
               "$value": {
                 "fontSize": "{core.fontSize.icon.step0}",
-                "fontFamily": "{core.fontFamilies.sage-icons}",
+                "fontFamily": "{global.fontFamilies.sage-icons}",
                 "paragraphSpacing": "{core.paragraphSpacing.0}"
               },
               "$description": "Small Viewports: 20, Large Viewports: 20. "
@@ -246,7 +246,7 @@
               "$type": "typography",
               "$value": {
                 "fontSize": "{core.fontSize.icon.step0}",
-                "fontFamily": "{core.fontFamilies.sage-icons}",
+                "fontFamily": "{global.fontFamilies.sage-icons}",
                 "paragraphSpacing": "{core.paragraphSpacing.0}"
               },
               "$description": "Small Viewports: 20, Large Viewports: 20. "
@@ -255,7 +255,7 @@
               "$type": "typography",
               "$value": {
                 "fontSize": "{core.fontSize.icon.step0}",
-                "fontFamily": "{core.fontFamilies.sage-icons}",
+                "fontFamily": "{global.fontFamilies.sage-icons}",
                 "paragraphSpacing": "{core.paragraphSpacing.0}"
               },
               "$description": "Small Viewports: 20, Large Viewports: 20. "
@@ -266,7 +266,7 @@
               "S": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.regular}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.fluid.step0}",
@@ -278,7 +278,7 @@
               "M": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.regular}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.fluid.step0}",
@@ -290,7 +290,7 @@
               "L": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.regular}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.fluid.step1}",
@@ -304,7 +304,7 @@
               "S": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.medium}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.fluid.step0}",
@@ -316,7 +316,7 @@
               "M": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.medium}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.fluid.step0}",
@@ -328,7 +328,7 @@
               "L": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.medium}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.fluid.step1}",
@@ -343,7 +343,7 @@
             "XS": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.stepMinus2}",
@@ -353,7 +353,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step0}",
@@ -363,7 +363,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step2}",
@@ -373,7 +373,7 @@
             "ML": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step4}",
@@ -383,7 +383,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step6}",
@@ -393,7 +393,7 @@
             "XL": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step8}",
@@ -403,7 +403,7 @@
             "XXL": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.fluid.step10}",
@@ -418,7 +418,7 @@
           "S": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.heading}",
+              "fontFamily": "{global.fontFamilies.heading}",
               "fontWeight": "{core.fontWeights.medium}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.static.large.step3}"
@@ -427,7 +427,7 @@
           "M": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.heading}",
+              "fontFamily": "{global.fontFamilies.heading}",
               "fontWeight": "{core.fontWeights.bold}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.static.large.step4}"
@@ -436,7 +436,7 @@
           "L": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.heading}",
+              "fontFamily": "{global.fontFamilies.heading}",
               "fontWeight": "{core.fontWeights.bold}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.static.large.step6}"
@@ -447,7 +447,7 @@
           "M": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.subheading}",
+              "fontFamily": "{global.fontFamilies.subheading}",
               "fontWeight": "{core.fontWeights.medium}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.static.large.step1}"
@@ -456,7 +456,7 @@
           "L": {
             "$type": "typography",
             "$value": {
-              "fontFamily": "{core.fontFamilies.subheading}",
+              "fontFamily": "{global.fontFamilies.subheading}",
               "fontWeight": "{core.fontWeights.medium}",
               "lineHeight": "{core.lineHeights.400}",
               "fontSize": "{core.fontSize.static.large.step2}"
@@ -468,7 +468,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.subheading}",
+                "fontFamily": "{global.fontFamilies.subheading}",
                 "fontWeight": "{core.fontWeights.bold}",
                 "lineHeight": "{core.lineHeights.400}",
                 "fontSize": "{core.fontSize.static.large.step1}"
@@ -477,7 +477,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.subheading}",
+                "fontFamily": "{global.fontFamilies.subheading}",
                 "fontWeight": "{core.fontWeights.bold}",
                 "lineHeight": "{core.lineHeights.400}",
                 "fontSize": "{core.fontSize.static.large.step3}"
@@ -490,7 +490,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -500,7 +500,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -510,7 +510,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step1}",
@@ -522,7 +522,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -532,7 +532,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -542,7 +542,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.body}",
+                "fontFamily": "{global.fontFamilies.body}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step1}",
@@ -556,7 +556,7 @@
             "XS": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.stepMinus1}",
@@ -566,7 +566,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -576,7 +576,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -586,7 +586,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step1}",
@@ -598,7 +598,7 @@
             "XS": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.stepMinus1}",
@@ -608,7 +608,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -618,7 +618,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -628,7 +628,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.regular}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step1}",
@@ -641,7 +641,7 @@
               "$type": "typography",
               "$value": {
                 "fontSize": "{core.fontSize.icon.step0}",
-                "fontFamily": "{core.fontFamilies.sage-icons}",
+                "fontFamily": "{global.fontFamilies.sage-icons}",
                 "paragraphSpacing": "{core.paragraphSpacing.0}"
               }
             },
@@ -649,7 +649,7 @@
               "$type": "typography",
               "$value": {
                 "fontSize": "{core.fontSize.icon.step0}",
-                "fontFamily": "{core.fontFamilies.sage-icons}",
+                "fontFamily": "{global.fontFamilies.sage-icons}",
                 "paragraphSpacing": "{core.paragraphSpacing.0}"
               }
             },
@@ -657,7 +657,7 @@
               "$type": "typography",
               "$value": {
                 "fontSize": "{core.fontSize.icon.step0}",
-                "fontFamily": "{core.fontFamilies.sage-icons}",
+                "fontFamily": "{global.fontFamilies.sage-icons}",
                 "paragraphSpacing": "{core.paragraphSpacing.0}"
               }
             }
@@ -667,7 +667,7 @@
               "S": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.regular}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.static.large.step0}",
@@ -679,7 +679,7 @@
               "M": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.regular}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.static.large.step0}",
@@ -691,7 +691,7 @@
               "L": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.regular}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.static.large.step1}",
@@ -705,7 +705,7 @@
               "S": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.medium}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.static.large.step0}",
@@ -717,7 +717,7 @@
               "M": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.medium}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.static.large.step0}",
@@ -729,7 +729,7 @@
               "L": {
                 "$type": "typography",
                 "$value": {
-                  "fontFamily": "{core.fontFamilies.component}",
+                  "fontFamily": "{global.fontFamilies.component}",
                   "fontWeight": "{core.fontWeights.medium}",
                   "lineHeight": "{core.lineHeights.500}",
                   "fontSize": "{core.fontSize.static.large.step1}",
@@ -744,7 +744,7 @@
             "XS": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.stepMinus2}",
@@ -754,7 +754,7 @@
             "S": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step0}",
@@ -764,7 +764,7 @@
             "M": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step2}",
@@ -774,7 +774,7 @@
             "ML": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step4}",
@@ -784,7 +784,7 @@
             "L": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step6}",
@@ -794,7 +794,7 @@
             "XL": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step8}",
@@ -804,7 +804,7 @@
             "XXL": {
               "$type": "typography",
               "$value": {
-                "fontFamily": "{core.fontFamilies.component}",
+                "fontFamily": "{global.fontFamilies.component}",
                 "fontWeight": "{core.fontWeights.medium}",
                 "lineHeight": "{core.lineHeights.500}",
                 "fontSize": "{core.fontSize.static.large.step10}",
@@ -813,6 +813,34 @@
             }
           }
         }
+      }
+    },
+    "fontFamilies": {
+      "heading": {
+        "$type": "fontFamilies",
+        "$value": "Sage UI"
+      },
+      "subheading": {
+        "$type": "fontFamilies",
+        "$value": "Sage UI"
+      },
+      "body": {
+        "$type": "fontFamilies",
+        "$value": "Sage UI"
+      },
+      "component": {
+        "$type": "fontFamilies",
+        "$value": "Sage UI",
+        "$description": "Used in componentry such as tables, buttons, inputs etc."
+      },
+      "sage-icons": {
+        "$type": "fontFamilies",
+        "$value": "sage-icons"
+      },
+      "other": {
+        "$type": "fontFamilies",
+        "$value": "Open Sans",
+        "$description": "Fallback for when Sage fonts cannot load."
       }
     }
   }

--- a/data/tokens/global/radius.json
+++ b/data/tokens/global/radius.json
@@ -6,6 +6,10 @@
         "$value": "0",
         "$description": "Button groups (internal/adjacent corners), Card select group (internal/adjacent corners), File input (integrated base bar top corners)."
       },
+      "scale": {
+        "$type": "borderRadius",
+        "$value": "1"
+      },
       "container": {
         "3XS": {
           "$type": "borderRadius",
@@ -14,45 +18,45 @@
         },
         "2XS": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.25}",
+          "$value": "{core.dimension.25} * {global.radius.scale}",
           "$description": "Pill"
         },
         "XS": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.50}"
+          "$value": "{core.dimension.50} * {global.radius.scale}"
         },
         "S": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.75}",
+          "$value": "{core.dimension.75} * {global.radius.scale}",
           "$description": "L size loader and tracker corners"
         },
         "M": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.100}",
+          "$value": "{core.dimension.100} * {global.radius.scale}",
           "$description": "Card select group (outer corners), Card select (single), Color picker advanced (inner swatch container), File input (file uploads & integrated progress bar (bottom corners),  File preview (File selector assets on left), Link preview, Message, Note, Popover (menu container in Action popover, Button-split, Button-multi-action, Calendar, Dropdown), Subscription tile (currently a pattern), Table (parent container), Tile & Tile flexbox (less rounded), Toast, Tooltip"
         },
         "L": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.200}",
+          "$value": "{core.dimension.200} * {global.radius.scale}",
           "$description": "Card (less rounded), Carousel (slides), Color picker advanced (parent container), File preview (parent container), Medium Tile & Tile flexbox, Medium Card."
         },
         "XL": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.300}",
+          "$value": "{core.dimension.300} * {global.radius.scale}",
           "$description": "Card (more  rounded), Copilot Container, Carousel (parent container), Dialog (not full screen), Large Tile & Tile flexbox, Large cards"
         },
         "2XL": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.400}"
+          "$value": "{core.dimension.400} * {global.radius.scale}"
         },
         "3XL": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.500}",
+          "$value": "{core.dimension.500} * {global.radius.scale}",
           "$description": "marketing cards and tiles"
         },
         "4XL": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.1000}",
+          "$value": "{core.dimension.1000} * {global.radius.scale}",
           "$description": "marketing images "
         },
         "circle": {
@@ -74,27 +78,27 @@
         },
         "S": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.50}",
+          "$value": "{core.dimension.50} * {global.radius.scale}",
           "$description": "S & M Checkboxes"
         },
         "M": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.100}",
+          "$value": "{core.dimension.100} * {global.radius.scale}",
           "$description": "Button subtle, L Checkboxes, Date picker input, Date range input, Dropdown select (trigger), Search, File input (draggable area),  Menu (bottom corners), Navigation: left (state bg shape), Skip focus, Tab, Text area, Text input,"
         },
         "L": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.200}",
+          "$value": "{core.dimension.200} * {global.radius.scale}",
           "$description": "Buttons S (typical and destructive, and inc bar, split and multi), Navigation left (collapsible Assets/Menu select top-right and bottom-right corners), "
         },
         "XL": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.250}",
+          "$value": "{core.dimension.250} * {global.radius.scale}",
           "$description": "Buttons M (typical and destructive and inc bar split and multi), Button toggle M (parent container)"
         },
         "2XL": {
           "$type": "borderRadius",
-          "$value": "{core.dimension.300}",
+          "$value": "{core.dimension.300} * {global.radius.scale}",
           "$description": "Buttons L (typical and destructive and inc bar split and multi), Button toggle L (parent container)"
         },
         "circle": {

--- a/scripts/formats/commonJSExports.ts
+++ b/scripts/formats/commonJSExports.ts
@@ -1,5 +1,5 @@
 import { Dictionary, DesignToken } from "style-dictionary/types";
-import { outputRefForToken } from "./outputRefForToken.js";
+import { outputRefForToken, resolveTypographyObject } from "./outputRefForToken.js";
 
 /**
  * Custom format to output ensure commonJS variables output in the same format as ESM
@@ -16,11 +16,20 @@ export const formatCommonJSExports = ({dictionary, options = {}}: {dictionary: D
 
       if (shouldOutputRef) {
         const originalValue = token["original"]?.value ?? token["original"]?.$value;
-        return `module.exports.${token.name} = "${outputRefForToken(originalValue, token)}";`;
+        return `module.exports.${token.name} = ${JSON.stringify(outputRefForToken(originalValue, token))};`;
       }
 
       const value = token.$value ?? token.value;
-      const serialized = typeof value === "object" ? JSON.stringify(value) : `"${value}"`;
+
+      let outValue: unknown = value;
+      if (value && typeof value === "object" && !Array.isArray(value)) {
+        const original = token["original"]?.$value ?? token["original"]?.value;
+        outValue = (original && typeof original === "object")
+          ? resolveTypographyObject(original as Record<string, unknown>, value as Record<string, unknown>)
+          : value;
+      }
+
+      const serialized = typeof outValue === "object" ? JSON.stringify(outValue) : `"${outValue}"`;
       return `module.exports.${token.name} = ${serialized};`;
     })
     .join('\n');

--- a/scripts/formats/commonJSWithRefs.ts
+++ b/scripts/formats/commonJSWithRefs.ts
@@ -15,7 +15,7 @@ export const outputCommonJSWithRefs = ({dictionary, options = {}}: {dictionary: 
         const originalValue = token["original"]?.value ?? token["original"]?.$value;
 
         if (outputReferences && token.name) {
-          return `module.exports.${token.name} = "${outputRefForToken(originalValue, token)}";`;
+          return `module.exports.${token.name} = ${JSON.stringify(outputRefForToken(originalValue, token))};`;
         }
 
         return "";

--- a/scripts/formats/outputES6WithRefs.ts
+++ b/scripts/formats/outputES6WithRefs.ts
@@ -1,31 +1,23 @@
 import { Dictionary, DesignToken } from "style-dictionary/types";
-import { outputRefForToken } from "./outputRefForToken.js";
+import { outputRefForToken, resolveTypographyObject } from "./outputRefForToken.js";
 
-const formatTypographyValue = (value: Record<string, unknown>): string => {
-    const fontSize = typeof value["fontSize"] === "string" ? value["fontSize"] : "";
-    const fontFamily = typeof value["fontFamily"] === "string" ? value["fontFamily"] : "";
-    const fontWeight = typeof value["fontWeight"] === "string" ? value["fontWeight"] : "";
-    const lineHeight = typeof value["lineHeight"] === "string" ? value["lineHeight"] : "";
+const formatNonRefValue = (token: DesignToken): unknown => {
+  const value = token.$value ?? token.value;
 
-    const sizeSegment = lineHeight ? `${fontSize}/${lineHeight}` : fontSize;
-    const weighted = fontWeight ? `${fontWeight} ${sizeSegment}` : sizeSegment;
-
-    return `${weighted} ${fontFamily}`.trim();
-  };
-
-const formatNonRefValue = (value: unknown): string => {
-    if (value && typeof value === "object" && !Array.isArray(value)) {
-      const objectValue = value as Record<string, unknown>;
-
-      if (typeof objectValue["fontSize"] === "string" && typeof objectValue["fontFamily"] === "string") {
-        return formatTypographyValue(objectValue);
-      }
-
-      return JSON.stringify(objectValue);
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const original = token["original"]?.$value ?? token["original"]?.value;
+    if (original && typeof original === "object") {
+      return resolveTypographyObject(
+        original as Record<string, unknown>,
+        value as Record<string, unknown>
+      );
     }
 
-    return String(value);
-  };
+    return value;
+  }
+
+  return String(value);
+};
 
 /**
  * Custom format to ensure ES6 variables output with CSS variable references to support white-labelling
@@ -51,9 +43,9 @@ export const outputES6WithRefs = ({dictionary, options = {}}: {dictionary: Dicti
         if (token.name) {
           const value = shouldOutputRef(token)
             ? outputRefForToken(originalValue, token)
-            : formatNonRefValue(token.$value || token.value);
+            : formatNonRefValue(token);
 
-          return `export const ${token.name} = "${value}";`;
+          return `export const ${token.name} = ${JSON.stringify(value)};`;
         }
 
         return "";

--- a/scripts/formats/outputJSONWithRefs.ts
+++ b/scripts/formats/outputJSONWithRefs.ts
@@ -1,27 +1,18 @@
 import { Dictionary, DesignToken } from "style-dictionary/types";
-import { outputRefForToken } from "./outputRefForToken.js";
+import { outputRefForToken, resolveTypographyObject } from "./outputRefForToken.js";
 
-const formatTypographyValue = (value: Record<string, unknown>): string => {
-  const fontSize = typeof value["fontSize"] === "string" ? value["fontSize"] : "";
-  const fontFamily = typeof value["fontFamily"] === "string" ? value["fontFamily"] : "";
-  const fontWeight = typeof value["fontWeight"] === "string" ? value["fontWeight"] : "";
-  const lineHeight = typeof value["lineHeight"] === "string" ? value["lineHeight"] : "";
+const formatNonRefValue = (token: DesignToken): unknown => {
+  const value = token.$value ?? token.value;
 
-  const sizeSegment = lineHeight ? `${fontSize}/${lineHeight}` : fontSize;
-  const weighted = fontWeight ? `${fontWeight} ${sizeSegment}` : sizeSegment;
-
-  return `${weighted} ${fontFamily}`.trim();
-};
-
-const formatNonRefValue = (value: unknown): string => {
   if (value && typeof value === "object" && !Array.isArray(value)) {
-    const objectValue = value as Record<string, unknown>;
-
-    if (typeof objectValue["fontSize"] === "string" && typeof objectValue["fontFamily"] === "string") {
-      return formatTypographyValue(objectValue);
+    const original = token["original"]?.$value ?? token["original"]?.value;
+    if (original && typeof original === "object") {
+      return resolveTypographyObject(
+        original as Record<string, unknown>,
+        value as Record<string, unknown>
+      );
     }
-
-    return JSON.stringify(objectValue);
+    return value;
   }
 
   return String(value);
@@ -51,7 +42,7 @@ export const outputJSONWithRefs = ({dictionary, options = {}}: {dictionary: Dict
         if (token.name) {
           acc[token.name] = shouldOutputRef(token)
             ? outputRefForToken(originalValue, token)
-            : formatNonRefValue(token.$value || token.value);
+            : formatNonRefValue(token);
         }
 
         return acc;

--- a/scripts/formats/outputRefForToken.ts
+++ b/scripts/formats/outputRefForToken.ts
@@ -1,23 +1,6 @@
 import { DesignToken } from "style-dictionary/types";
 import { usesReferences } from 'style-dictionary/utils';
-
-/**
- * Helper: Converts a reference path to proper kebab-case for CSS variable names
- * @param refPath The reference path (e.g., "mode.color.action.mainWithDefault")
- * @returns The kebab-case CSS variable name
- */
-const convertToKebabCase = (refPath: string): string => {
-  return refPath
-    .split('.')
-    .map(segment => {
-      // Convert camelCase segments to kebab-case
-      return segment
-        .replace(/([a-z\d])([A-Z])/g, '$1-$2') // Handle lowercase/digit + uppercase
-        .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2') // Handle consecutive capitals
-        .toLowerCase();
-    })
-    .join('-');
-};
+import { convertToKebabCase } from "../utils/convert-to-kebab-case.js";
 
 /**
  * Helper: Check if a value contains mathematical operations
@@ -97,18 +80,28 @@ type TypographyTokenValue = {
   fontSize: string;
 };
 
-/**
- * Helper: Convert a typography object to a CSS font shorthand string
- */
-const processTypography = (
-  typography: TypographyTokenValue
-): string => {
-  const fontWeight = processReferences(typography.fontWeight);
-  const fontSize = processReferences(typography.fontSize);
-  const lineHeight = processReferences(typography.lineHeight);
-  const fontFamily = processReferences(typography.fontFamily);
-  
-  return `${fontWeight} ${fontSize}/${lineHeight} ${fontFamily}`;
+export const resolveTypographyObject = (
+  original: Record<string, unknown>,
+  resolved: Record<string, unknown> = {}
+): Record<string, unknown> => {
+  const result: Record<string, unknown> = {};
+
+  for (const key of Object.keys(original)) {
+    const orig = original[key];
+
+    if (typeof orig === "string" && usesReferences(orig) && /\{global\./.test(orig)) {
+      result[key] = orig.replace(/\{([^}]+)\}/g, (match, refPath: string) =>
+        refPath.startsWith("global.")
+          ? `var(--${convertToKebabCase(refPath)})`
+          : String(resolved[key])
+      );
+    } else {
+      // core.* refs and literals: use the already-resolved value as-is (number stays number)
+      result[key] = resolved[key];
+    }
+  }
+
+  return result;
 };
 
 /**
@@ -117,7 +110,7 @@ const processTypography = (
  * @param token The design token object
  * @returns The processed value with CSS variable references where applicable
  */
-export const outputRefForToken = (originalValue: string | TypographyTokenValue | BoxShadowTokenValue, token: DesignToken): string => {
+export const outputRefForToken = (originalValue: string | TypographyTokenValue | BoxShadowTokenValue, token: DesignToken): string | Record<string, unknown> => {
   // Handle boxShadow arrays
   if (Array.isArray(originalValue)) {
     return processBoxShadow(originalValue);
@@ -125,7 +118,8 @@ export const outputRefForToken = (originalValue: string | TypographyTokenValue |
 
   // Handle typography objects
   if (typeof originalValue === 'object') {
-    return processTypography(originalValue);
+    const resolved = (token.$value ?? token.value) as Partial<TypographyTokenValue>;
+    return resolveTypographyObject(originalValue as Record<string, unknown>, resolved);
   }
 
   if (usesReferences(originalValue)) {

--- a/scripts/style-dictionary.ts
+++ b/scripts/style-dictionary.ts
@@ -5,6 +5,7 @@ Copyright © 2025 The Sage Group plc or its licensors. All Rights reserved
 import StyleDictionary from "style-dictionary"
 import { register } from "@tokens-studio/sd-transforms"
 import { removeComments } from "./transforms/removeComments.js";
+import { handleFontFamiliesReferencesCSS, handleFontFamiliesReferencesScss } from "./transforms/handleFontFamilyReferences.js";
 import { outputJSONWithRefs } from "./formats/outputJSONWithRefs.js";
 import { outputES6WithRefs } from "./formats/outputES6WithRefs.js";
 import { outputCommonJSWithRefs } from "./formats/commonJSWithRefs.js";
@@ -37,6 +38,22 @@ StyleDictionary.registerTransform({
   transform: removeComments
 });
 
+StyleDictionary.registerTransform({
+  name: "custom/typography-global-family",
+  type: "value",
+  transitive: true,
+  filter: (token) => (token.$type ?? token.type) === "typography",
+  transform: handleFontFamiliesReferencesCSS,
+});
+
+StyleDictionary.registerTransform({
+  name: "custom/typography-global-family-scss",
+  type: "value",
+  transitive: true,
+  filter: (token) => (token.$type ?? token.type) === "typography",
+  transform: handleFontFamiliesReferencesScss,
+});
+
 const groups = {
   css: [
     "custom/remove-comments",
@@ -44,13 +61,13 @@ const groups = {
     "border/css/shorthand",
     "shadow/css/shorthand",
     "transition/css/shorthand",
-    "typography/css/shorthand",
     "name/kebab",
     "ts/size/px",
     "ts/opacity",
     "ts/size/lineheight",
     "ts/typography/fontWeight",
     "ts/resolveMath",
+    "custom/typography-global-family",
     "ts/size/css/letterspacing",
     "ts/color/modifiers"
   ],
@@ -60,13 +77,13 @@ const groups = {
     "border/css/shorthand",
     "shadow/css/shorthand",
     "transition/css/shorthand", 
-    "typography/css/shorthand",
     "name/kebab",
     "ts/size/px",
     "ts/opacity",
     "ts/size/lineheight",
     "ts/typography/fontWeight",
     "ts/resolveMath",
+    "custom/typography-global-family-scss",
     "ts/size/css/letterspacing",
     "ts/color/modifiers"
   ],

--- a/scripts/transforms/handleFontFamilyReferences.ts
+++ b/scripts/transforms/handleFontFamilyReferences.ts
@@ -1,0 +1,25 @@
+import { convertToKebabCase } from "../utils/convert-to-kebab-case.js";
+import type { DesignToken } from "style-dictionary/types";
+
+const buildTypographyShorthand = (
+  token: DesignToken,
+  formatRef: (kebab: string) => string
+): string => {
+  const original = (token["original"]?.$value ?? token["original"]?.value) ?? {};
+  const resolved = (token.$value ?? token.value) ?? {};
+
+  const rawFamily = original.fontFamily as string | undefined;
+  const family = rawFamily && /\{global\./.test(rawFamily)
+    ? rawFamily.replace(/\{([^}]+)\}/g, (_m, p) => formatRef(convertToKebabCase(p)))
+    : resolved.fontFamily;
+
+  const sizePart = resolved.lineHeight ? `${resolved.fontSize}/${resolved.lineHeight}` : resolved.fontSize;
+  const weighted = resolved.fontWeight ? `${resolved.fontWeight} ${sizePart}` : sizePart;
+  return `${weighted} ${family}`.trim();
+};
+
+export const handleFontFamiliesReferencesCSS = (token: DesignToken): string =>
+  buildTypographyShorthand(token, (kebab) => `var(--${kebab})`);
+
+export const handleFontFamiliesReferencesScss = (token: DesignToken): string =>
+  buildTypographyShorthand(token, (kebab) => `$${kebab}`);

--- a/scripts/utils/convert-to-kebab-case.ts
+++ b/scripts/utils/convert-to-kebab-case.ts
@@ -1,0 +1,17 @@
+/**
+ * Helper: Converts a reference path to proper kebab-case for CSS variable names
+ * @param refPath The reference path (e.g., "mode.color.action.mainWithDefault")
+ * @returns The kebab-case CSS variable name
+ */
+export const convertToKebabCase = (refPath: string): string => {
+  return refPath
+    .split('.')
+    .map(segment => {
+      // Convert camelCase segments to kebab-case
+      return segment
+        .replace(/([a-z\d])([A-Z])/g, '$1-$2') // Handle lowercase/digit + uppercase
+        .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2') // Handle consecutive capitals
+        .toLowerCase();
+    })
+    .join('-');
+};

--- a/tests/global-mode-tokens.test.ts
+++ b/tests/global-mode-tokens.test.ts
@@ -82,7 +82,7 @@ describe("Global tokens", () => {
     
     // Should have the expected properties
     if (typeof fontToken === "object") {
-      expect(fontToken.fontFamily).toBe("Sage UI");
+      expect(fontToken.fontFamily).toBe("var(--global-font-families-heading)");
       expect(fontToken.fontWeight).toBe("500");
       expect(fontToken.lineHeight).toBe(1.25);
       expect(fontToken.fontSize).toContain("clamp");

--- a/tests/override-references.test.ts
+++ b/tests/override-references.test.ts
@@ -33,6 +33,10 @@ const depthTokenCamelKeys = [
   "globalDepthStickyT",
 ];
 
+const isFontTypographyToken = (key: string) =>
+  /^global-font-(fluid|static)-/.test(key) || /^globalFont(Fluid|Static)/.test(key);
+
+
 function parseScssFile(filePath: string): Map<string, string> {
   const content = readFileSync(filePath, "utf-8");
   const tokens = new Map<string, string>();
@@ -48,8 +52,29 @@ function parseScssFile(filePath: string): Map<string, string> {
   return tokens;
 }
 
+function mergeLooseExports(
+  filePath: string,
+  base: Map<string, string>,
+  pattern: RegExp
+): Map<string, string> {
+  const content = readFileSync(filePath, "utf-8");
+  const merged = new Map(base);
+  let match;
+
+  while ((match = pattern.exec(content)) !== null) {
+    const [, key, rhs] = match;
+    if (key && rhs && !merged.has(key)) {
+      // raw RHS so objects/numbers inlcuded
+      merged.set(key, rhs.trim());
+    }
+  }
+
+  return merged;
+}
+
 type GlobalFormatCase = {
   name: string;
+  filePath: string;
   globalTokens: Map<string, string>;
   depthKeys: string[];
   depthRefPrefix: string;
@@ -59,6 +84,7 @@ type GlobalFormatCase = {
 const globalFormatCases: GlobalFormatCase[] = [
   {
     name: "CSS",
+    filePath: resolve(distPath, "css/global.css"),
     globalTokens: parseCSSFile(resolve(distPath, "css/global.css")),
     depthKeys: depthTokenKeys,
     depthRefPrefix: "var(--mode-color-generic-depth-",
@@ -66,6 +92,7 @@ const globalFormatCases: GlobalFormatCase[] = [
   },
   {
     name: "SCSS",
+    filePath: resolve(distPath, "scss/global.scss"),
     globalTokens: parseScssFile(resolve(distPath, "scss/global.scss")),
     depthKeys: depthTokenKeys,
     depthRefPrefix: "$mode-color-generic-depth-",
@@ -73,21 +100,32 @@ const globalFormatCases: GlobalFormatCase[] = [
   },
   {
     name: "JSON",
+    filePath: resolve(distPath, "json/global.json"),
     globalTokens: parseJSONFile(resolve(distPath, "json/global.json")),
     depthKeys: depthTokenCamelKeys,
     depthRefPrefix: "var(--mode-color-generic-depth-",
     nonDepthRefPatterns: [/var\(--/],
   },
-  {
+    {
     name: "CommonJS",
-    globalTokens: parseCommonJSFile(resolve(distPath, "js/common/global.js")),
+    filePath: resolve(distPath, "js/common/global.js"),
+    globalTokens: mergeLooseExports(
+      resolve(distPath, "js/common/global.js"),
+      parseCommonJSFile(resolve(distPath, "js/common/global.js")),
+      /module\.exports\.(\w+)\s*=\s*(.+);\s*$/gm // capture module.exports lines with RHS incl.
+    ),
     depthKeys: depthTokenCamelKeys,
     depthRefPrefix: "var(--mode-color-generic-depth-",
     nonDepthRefPatterns: [/var\(--/],
   },
   {
     name: "ES module",
-    globalTokens: parseES6File(resolve(distPath, "js/es6/global.js")),
+    filePath: resolve(distPath, "js/es6/global.js"),
+    globalTokens: mergeLooseExports(
+      resolve(distPath, "js/es6/global.js"),
+      parseES6File(resolve(distPath, "js/es6/global.js")),
+      /export const (\w+)\s*=\s*(.+);\s*$/gm // capture export const lines with RHS incl.
+    ),
     depthKeys: depthTokenCamelKeys,
     depthRefPrefix: "var(--mode-color-generic-depth-",
     nonDepthRefPatterns: [/var\(--/],
@@ -96,20 +134,21 @@ const globalFormatCases: GlobalFormatCase[] = [
 
 describe.each(globalFormatCases)(
   "Global depth references - $name",
-  ({ globalTokens, depthKeys, depthRefPrefix, nonDepthRefPatterns }) => {
+  ({ globalTokens, depthKeys, depthRefPrefix, nonDepthRefPatterns, name, filePath }) => {
     it("intended depth tokens include mode refs", () => {
       depthKeys.forEach(tokenName => {
         const value = globalTokens.get(tokenName);
+
         expect(value).toBeTruthy();
         expect(value).toContain(depthRefPrefix);
       });
     });
 
-    it("non-depth tokens do not include any refs", () => {
+    it("only includes refs for depth and typography tokens", () => {
       const depthSet = new Set(depthKeys);
 
       globalTokens.forEach((value, key) => {
-        if (depthSet.has(key)) {
+        if (depthSet.has(key) || isFontTypographyToken(key)) {
           return;
         }
 
@@ -117,6 +156,25 @@ describe.each(globalFormatCases)(
           expect(value).not.toMatch(pattern);
         });
       });
+    });
+
+    it("font typography tokens reference the global font family", () => {
+      const familyRef = name.includes("SCSS")
+        ? "$global-font-families-"
+        : "var(--global-font-families-";
+
+      if (name.includes("SCSS")) {
+        const typographyValues = Array.from(globalTokens.entries())
+          .filter(([key]) => isFontTypographyToken(key))
+          .map(([, value]) => value);
+       
+        expect(typographyValues.some(v => v.includes(familyRef))).toBe(true);
+        return;
+      }
+
+      const content = readFileSync(filePath, "utf-8");
+
+      expect(content).toContain(familyRef);
     });
   }
 );


### PR DESCRIPTION
### Proposed behaviour
- Add scale mid token for radius adjustment. {global.radius.scale}
- Move font family tokens to mid layer e.g {global.fontFamilies.heading}

build changes:

- adds custom transform for CSS and SCSS to handle including new global token references
- updates tests to handle font token references
- tidies up custom formatters for JSON and JS outputs

TODO:
At some point we should spike what white-labelling would look like when using SCSS, `$` referencing means it will need to be handled at build time not run time. As we need to review the whole SCSS output at some point anyway so it's compatible with DART 3.0 (and because it doesn't affect carbon) I've just left this as is for now

### Current behaviour
<!--
A clear and concise description of the behaviour before this change. If applicable, include any UI screenshots to help explain your request. If you are a Sage contributor, please DO NOT share any commercially sensitive information, such as UI screenshots or code from Sage products.
-->

### Design Tokens
<!-- If this PR includes design token changes, please indicate which of the following apply -->
- [x] Token values updated
- [x] New tokens added
- [ ] Tokens removed/renamed

<!-- If tokens were removed or renamed, please list them here for clarity -->
**Tokens removed/renamed:**
<!-- e.g., `color-primary` → `color-brand-primary` -->

### Checklist
<!-- Each PR should include the following -->
- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Related docs have been updated if required

### QA
<!-- Testing performed by QA -->

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!--
How can a reviewer test this PR?
-->