### PR TITLE
feat(container): add ghost opacity token

### DIFF
--- a/data/tokens/components/container.json
+++ b/data/tokens/components/container.json
@@ -387,6 +387,13 @@
           }
         }
       }
+    },
+    "draggable": {
+      "ghost": {
+        "$type": "opacity",
+        "$value": "{global.modifier.draggable.ghost}",
+        "$description": "ghost state for draggable table row, tile or card"
+      }
     }
   }
 }


### PR DESCRIPTION
### Proposed behaviour
Add a new opacity token for consumption on tables, tile and card

### Current behaviour
no opacity draggable token exists

### Design Tokens
<!-- If this PR includes design token changes, please indicate which of the following apply -->
- [ ] Token values updated
- [x] New tokens added
- [ ] Tokens removed/renamed

<!-- If tokens were removed or renamed, please list them here for clarity -->
**Tokens removed/renamed:**
<!-- e.g., `color-primary` → `color-brand-primary` -->

### Checklist
<!-- Each PR should include the following -->
- [ ] Commits follow our style guide
- [ ] Related issues linked in commit messages if required
- [ ] Screenshots are included in the PR if useful
- [ ] All themes are supported if required
- [ ] Unit tests added or updated if required
- [ ] Related docs have been updated if required

### QA
<!-- Testing performed by QA -->

### Additional context
<!-- Add any other context or links about the pull request here. -->

### Testing instructions
<!--
How can a reviewer test this PR?
-->